### PR TITLE
Move keyserver to hkp://:80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ mariadb CHANGELOG
 
 This file is used to list changes made in each version of the mariadb cookbook.
 
+0.2.12
+------
+- [BUG] - Push gpg key adds through http/80 - Helps with firewalled installs
+
 0.2.11
 ------
 - [ENH #38] - Add CentOS support

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sinfomicien@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures MariaDB'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.2.11'
+version '0.2.12'
 
 supports 'ubuntu'
 supports 'debian', '>= 7.0'

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -15,7 +15,7 @@ if node['mariadb']['use_default_repository']
         node['mariadb']['install']['version'] + '/' +  node['platform']
       distribution node['lsb']['codename']
       components ['main']
-      keyserver 'keyserver.ubuntu.com'
+      keyserver 'hkp://keyserver.ubuntu.com:80'
       key '0xcbcb082a1bb943db'
     end
   when 'yum'


### PR DESCRIPTION
Some corporate firewalls dont allow requests to tcp/11371 (default
for gpg ops for adding signing keys).  The keyserver.ubuntu.com install
supports access to hkp over tcp/80.
