### PR TITLE
Add cookbook attribute on configuration lwrp

### DIFF
--- a/providers/configuration.rb
+++ b/providers/configuration.rb
@@ -20,6 +20,7 @@ action :add do
     owner 'root'
     group 'mysql'
     mode '0640'
+    cookbook new_resource.cookbook
     variables variables_hash
   end
 end

--- a/resources/configuration.rb
+++ b/resources/configuration.rb
@@ -10,3 +10,4 @@ default_action :add
 attribute :conf_name, kind_of: String, name_attribute: true
 attribute :section, kind_of: String
 attribute :option,  kind_of: Hash, default: {}
+attribute :cookbook, kind_of: String, default: nil


### PR DESCRIPTION
This will allow to use the provider outside of the mariadb cookbook without having to copy `templates/default/generic.cnf.erb`
