### PR TITLE
set default hostname in client config

### DIFF
--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -19,7 +19,9 @@
 [client]
 port		= <%= node['mariadb']['client']['port']   %>
 socket		= <%= node['mariadb']['client']['socket'] %>
-host		= <%= node['mariadb']['client']['host'] ||= 'localhost' %>
+<% unless node['mariadb']['client']['host'].nil? %>
+host		= <%= node['mariadb']['client']['host'] %>
+<% end %>
 
 # Here is entries for some specific programs
 # The following values assume you have at least 32M ram

--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -19,6 +19,7 @@
 [client]
 port		= <%= node['mariadb']['client']['port']   %>
 socket		= <%= node['mariadb']['client']['socket'] %>
+host		= <%= node['mariadb']['client']['host'] ||= 'localhost' %>
 
 # Here is entries for some specific programs
 # The following values assume you have at least 32M ram


### PR DESCRIPTION
In our infrastructure, we need to run the mariadb CLI on the application server with the mariadb server running on a different node.
For this purpose, it's useful to set the default host in the client config. This PL allows to set `node['mariadb']['client']['host']` (default value: `localhost`).
