### PR TITLE
Add support to use os shipped package for CentOS7 or fedora 19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ mariadb CHANGELOG
 
 This file is used to list changes made in each version of the mariadb cookbook.
 
+0.3.0
+------
+- [ENH] - Add support for using operating system shipped mariadb packages
+
 0.2.12
 ------
 - [BUG] - Push gpg key adds through http/80 - Helps with firewalled installs

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Attributes
     <td>The http base url to use when installing from default repository</td>
     <td><tt>'ftp.igh.cnrs.fr/pub/mariadb/repo'</tt></td>
   </tr>
+  <tr>
+    <td><tt>['mariadb']['install']['prefer_os_package']</tt></td>
+    <td>Boolean</td>
+    <td>Indicator for preferring use packages shipped by running os</td>
+    <td><tt>false</tt></td>
+  </tr>
 </table>
 
 Usage

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -19,8 +19,9 @@ end
 # mysqld default configuration
 #
 default['mariadb']['forbid_remote_root']                = true
-default['mariadb']['server_root_password']		= ''
+default['mariadb']['server_root_password']              = ''
 default['mariadb']['allow_root_pass_change']            = false
+default['mariadb']['mysqld']['service_name']            = 'mysql'
 default['mariadb']['mysqld']['user']                    = 'mysql'
 default['mariadb']['mysqld']['port']                    = '3306'
 default['mariadb']['mysqld']['basedir']                 = '/usr'
@@ -129,6 +130,7 @@ default['mariadb']['debian']['host']     = 'localhost'
 #  hope to have 'from_source' in the near future
 default['mariadb']['install']['type'] = 'package'
 default['mariadb']['install']['version'] = '10.0'
+default['mariadb']['install']['prefer_os_package'] = false
 
 #
 # package(apt or yum) default configuration

--- a/libraries/mariadb_helper.rb
+++ b/libraries/mariadb_helper.rb
@@ -30,5 +30,49 @@ module MariaDB
       restart = true unless port_open?(ip, port)
       restart
     end
+
+    # Helper to determine if running operating system shipped a package for
+    # mariadb server & client. No galera shipped in any os yet.
+    # @param [String] os_platform Indicate operating system type, e.g. centos
+    # @param [String] os_version Indicate operating system version, e.g. 7.0
+    def os_package_provided?(os_platform, os_version)
+      package_provided = false
+      case os_platform
+      when 'centos', 'redhat'
+        package_provided = true if os_version.to_i == 7
+      when 'fedora'
+        package_provided = true if os_version.to_i >= 19
+      end
+      package_provided
+    end
+
+    # Helper to determine mariadb server service name shipped by native package
+    # If no native package available on this platform, return nil
+    # @param [String] os_platform Indicate operating system type, e.g. centos
+    # @param [String] os_version Indicate operating system version, e.g. 7.0
+    def os_service_name(os_platform, os_version)
+      return nil unless os_package_provided?(os_platform, os_version)
+      service_name = 'mariadb'
+      if os_platform == 'fedora' && os_version.to_i == 19
+        service_name = 'mysqld'
+      end
+      service_name
+    end
+
+    # Helper to determine whether to use os native package
+    # @param [Boolean] prefer_os Indicate whether to prefer os native package
+    # @param [String] os_platform Indicate operating system type, e.g. centos
+    # @param [String] os_version Indicate operating system version, e.g. 7.0
+    def use_os_native_package?(prefer_os, os_platform, os_version)
+      return false unless prefer_os
+      if os_package_provided?(os_platform, os_version)
+        true
+      else
+        Chef::Log.warn 'prefer_os_package detected, but no native mariadb'\
+          " package available on #{os_platform}-#{os_version}."\
+          ' Fall back to use community package.'
+        false
+      end
+    end
   end
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,11 +4,12 @@ maintainer_email 'sinfomicien@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures MariaDB'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.2.12'
+version '0.3.0'
 
 supports 'ubuntu'
 supports 'debian', '>= 7.0'
 supports 'centos', '>= 6.4'
+supports 'redhat', '>= 7.0'
 
 depends 'apt'
 depends 'yum'

--- a/providers/replication.rb
+++ b/providers/replication.rb
@@ -51,11 +51,11 @@ action :add do
   execute 'add_replication_from_master_' + new_resource.name do
     # Add sensitive true when foodcritic #233 fixed
     command '/bin/echo "' + sql_string + '" | ' + get_mysql_command(
-        new_resource.host,
-        new_resource.port,
-        new_resource.user,
-        new_resource.password
-      )
+      new_resource.host,
+      new_resource.port,
+      new_resource.user,
+      new_resource.password
+    )
     action :run
   end
 end

--- a/recipes/_audit_plugin.rb
+++ b/recipes/_audit_plugin.rb
@@ -18,13 +18,13 @@ audit_plugin_options['enable'] = '#server_audit_logging = ON'
 
 # Install the MariaDB Audit Plugin
 execute 'install_mariadb_audit_plugin' do
-  command '/usr/bin/mysql -e "INSTALL PLUGIN server_audit ' + \
+  command '/usr/bin/mysql -e "INSTALL PLUGIN server_audit '\
     'SONAME \'server_audit\';"'
   notifies :run, 'execute[configure_mariadb_audit_plugin]', :immediately
   not_if do
-    cmd = Mixlib::ShellOut.new('/usr/bin/mysql -u root -B -N -e "SELECT 1 ' + \
-                    'FROM information_schema.plugins ' + \
-                    'WHERE PLUGIN_NAME = \'SERVER_AUDIT\'' + \
+    cmd = Mixlib::ShellOut.new('/usr/bin/mysql -u root -B -N -e "SELECT 1 '\
+                    'FROM information_schema.plugins '\
+                    'WHERE PLUGIN_NAME = \'SERVER_AUDIT\''\
                     'AND PLUGIN_STATUS = \'ACTIVE\';"')
     cmd.run_command
     cmd.stdout.to_i == 1

--- a/recipes/_redhat_server_native.rb
+++ b/recipes/_redhat_server_native.rb
@@ -1,0 +1,44 @@
+#
+# Cookbook Name:: mariadb
+# Recipe:: _redhat_server_native
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This recipe is for install and configure os shipped mariadb package
+
+Chef::Recipe.send(:include, MariaDB::Helper)
+
+service_name = os_service_name(node['platform'], node['platform_version'])
+node.set['mariadb']['mysqld']['service_name'] = service_name\
+  unless service_name.nil?
+
+directory '/var/log/mysql' do
+  action :create
+  user 'mysql'
+  group 'mysql'
+  mode '0755'
+end
+
+package 'mariadb-server' do
+  action :install
+  notifies :start, 'service[mysql]', :immediately
+  notifies :run, 'execute[change first install root password]', :immediately
+end
+
+execute 'change first install root password' do
+  # Add sensitive true when foodcritic #233 fixed
+  command '/usr/bin/mysqladmin -u root password \'' + \
+    node['mariadb']['server_root_password'] + '\''
+  action :nothing
+  not_if { node['mariadb']['server_root_password'].empty? }
+end

--- a/recipes/galera.rb
+++ b/recipes/galera.rb
@@ -118,11 +118,11 @@ if platform?('debian', 'ubuntu')
 
   execute 'correct-debian-grants' do
     # Add sensitive true when foodcritic #233 fixed
-    command 'mysql -r -B -N -e "GRANT SELECT, INSERT, UPDATE, DELETE, ' + \
-      'CREATE, DROP, RELOAD, SHUTDOWN, PROCESS, FILE, REFERENCES, INDEX, ' + \
-      'ALTER, SHOW DATABASES, SUPER, CREATE TEMPORARY TABLES, ' + \
-      'LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, ' + \
-      'CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, ' + \
+    command 'mysql -r -B -N -e "GRANT SELECT, INSERT, UPDATE, DELETE, '\
+      'CREATE, DROP, RELOAD, SHUTDOWN, PROCESS, FILE, REFERENCES, INDEX, '\
+      'ALTER, SHOW DATABASES, SUPER, CREATE TEMPORARY TABLES, '\
+      'LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, '\
+      'CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, '\
       "CREATE USER, EVENT, TRIGGER ON *.* TO '" + \
       node['mariadb']['debian']['user'] + \
       "'@'" + node['mariadb']['debian']['host'] + "' IDENTIFIED BY '" + \

--- a/spec/centos_spec.rb
+++ b/spec/centos_spec.rb
@@ -2,10 +2,9 @@ require 'spec_helper'
 
 describe 'centos::mariadb::default' do
   let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(
-                                   platform: 'centos', version: '6.4',
-                                   step_into: ['mariadb_configuration']
-                                 ) do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.4',
+                                      step_into: ['mariadb_configuration']
+                                     ) do |node|
       node.automatic['memory']['total'] = '2048kB'
       node.automatic['ipaddress'] = '1.1.1.1'
     end
@@ -57,12 +56,97 @@ describe 'centos::mariadb::default' do
   end
 end
 
+describe 'centos::mariadb::native' do
+  let(:chef_run) do
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '7.0',
+                                      step_into: ['mariadb_configuration']
+                                     ) do |node|
+      node.automatic['memory']['total'] = '2048kB'
+      node.automatic['ipaddress'] = '1.1.1.1'
+      node.set['mariadb']['install']['prefer_os_package'] = true
+    end
+    runner.converge('mariadb::default')
+  end
+
+  context 'support for os shipped package' do
+    let(:os_package) { chef_run.package('mariadb-server') }
+    let(:os_service) { chef_run.service('mysql') }
+
+    it 'Include native recipe' do
+      expect(chef_run).to include_recipe('mariadb::_redhat_server_native')
+      expect(chef_run).not_to include_recipe('mariadb::repository')
+      expect(chef_run).not_to include_recipe('mariadb::_redhat_server')
+    end
+
+    it 'Install os shipped package' do
+      expect(chef_run).to install_package('mariadb-server')
+      expect(os_package).to notify('service[mysql]').to(:start).immediately
+    end
+
+    it 'Create Log directory' do
+      expect(chef_run).to create_directory('/var/log/mysql')
+    end
+
+    it 'Server service with the correct name' do
+      expect(os_service.service_name).to eq 'mariadb'
+    end
+    context 'fedora 19 with different service name' do
+      let(:chef_run) do
+        runner = ChefSpec::SoloRunner.new(platform: 'fedora', version: '19',
+                                          step_into: ['mariadb_configuration']
+                                         ) do |node|
+          node.automatic['memory']['total'] = '2048kB'
+          node.automatic['ipaddress'] = '1.1.1.1'
+          node.set['mariadb']['install']['prefer_os_package'] = true
+        end
+        runner.converge('mariadb::default')
+      end
+      let(:os_service) { chef_run.service('mysql') }
+
+      it 'Server service with the correct name' do
+        expect(os_service.service_name).to eq 'mysqld'
+      end
+    end
+  end
+
+  context ''
+  it 'Configure includedir in /etc/my.cnf' do
+    expect(chef_run).to create_template('/etc/my.cnf')
+    expect(chef_run).to render_file('/etc/my.cnf')
+      .with_content(%r{/etc/my.cnf.d})
+  end
+
+  it 'Configure replication in /etc/my.cnf.d/replication.cnf' do
+    expect(chef_run).to create_template('/etc/my.cnf.d/replication.cnf')
+    expect(chef_run).to render_file('/etc/my.cnf.d/replication.cnf')
+  end
+
+  it 'Configure InnoDB with attributes' do
+    expect(chef_run).to add_mariadb_configuration('innodb')
+    expect(chef_run).to render_file('/etc/my.cnf.d/innodb.cnf')
+      .with_content(/innodb_buffer_pool_size = 256M/)
+    expect(chef_run).to create_template('/etc/my.cnf.d/innodb.cnf')
+      .with(
+        user:  'root',
+        group: 'mysql',
+        mode:  '0640'
+      )
+  end
+
+  it 'Configure Replication' do
+    expect(chef_run).to add_mariadb_configuration('replication')
+  end
+
+  it 'Don t execute root password change at install' do
+    expect(chef_run).to_not run_execute('change first install root password')
+  end
+end
+
 describe 'centos::mariadb::client' do
   let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(
-                                   platform: 'centos', version: '6.4',
-                                   step_into: ['mariadb_configuration']
-                                 ) do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.4',
+                                      step_into: ['mariadb_configuration']
+                                     ) do |node|
       node.automatic['memory']['total'] = '2048kB'
       node.automatic['ipaddress'] = '1.1.1.1'
     end
@@ -82,10 +166,9 @@ describe 'centos::mariadb::client' do
   end
   context 'Without development files' do
     let(:chef_run) do
-      runner = ChefSpec::SoloRunner.new(
-                                     platform: 'centos', version: '6.4',
-                                     step_into: ['mariadb_configuration']
-                                   ) do |node|
+      runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '6.4',
+                                        step_into: ['mariadb_configuration']
+                                       ) do |node|
         node.automatic['memory']['total'] = '2048kB'
         node.automatic['ipaddress'] = '1.1.1.1'
         node.set['mariadb']['client']['development_files'] = false
@@ -99,6 +182,51 @@ describe 'centos::mariadb::client' do
 
     it 'Don t install MariaDB Client Devel Package' do
       expect(chef_run).to_not install_package('MariaDB-devel')
+    end
+  end
+end
+
+describe 'centos::mariadb::client::native' do
+  let(:chef_run) do
+    runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '7.0',
+                                      step_into: ['mariadb_configuration']
+                                     ) do |node|
+      node.automatic['memory']['total'] = '2048kB'
+      node.automatic['ipaddress'] = '1.1.1.1'
+      node.set['mariadb']['install']['prefer_os_package'] = true
+    end
+    runner.converge('mariadb::client')
+  end
+
+  it 'Do not remove mysql-libs' do
+    expect(chef_run).not_to remove_package('mysql-libs')
+  end
+
+  it 'Install MariaDB Client and Devel Package shipped by os' do
+    expect(chef_run).not_to include_recipe('mariadb::repository')
+    expect(chef_run).to install_package('mariadb')
+    expect(chef_run).to install_package('mariadb-devel')
+  end
+
+  context 'Without development files' do
+    let(:chef_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'centos', version: '7.0',
+                                        step_into: ['mariadb_configuration']
+                                       ) do |node|
+        node.automatic['memory']['total'] = '2048kB'
+        node.automatic['ipaddress'] = '1.1.1.1'
+        node.set['mariadb']['install']['prefer_os_package'] = true
+        node.set['mariadb']['client']['development_files'] = false
+      end
+      runner.converge('mariadb::client')
+    end
+
+    it 'Install MariaDB Client Package' do
+      expect(chef_run).to install_package('mariadb')
+    end
+
+    it 'Don t install MariaDB Client Devel Package' do
+      expect(chef_run).to_not install_package('mariadb-devel')
     end
   end
 end

--- a/spec/debian_galera10_spec.rb
+++ b/spec/debian_galera10_spec.rb
@@ -4,10 +4,9 @@ include Chef::Mixin::ShellOut
 
 describe 'debian::mariadb::galera10-rsync' do
   let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(
-                                   platform: 'debian', version: '7.4',
-                                   step_into: ['mariadb_configuration']
-                                 ) do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'debian', version: '7.4',
+                                      step_into: ['mariadb_configuration']
+                                     ) do |node|
       node.automatic['memory']['total'] = '2048kB'
       node.automatic['ipaddress'] = '1.1.1.1'
       node.set['mariadb']['rspec'] = true
@@ -94,7 +93,7 @@ describe 'debian::mariadb::galera10-rsync' do
 
   it 'Does not correct Grants for debian-sys-maint user if it s ok' do
     expect(Mixlib::ShellOut).to receive(:new)
-      .with('/usr/bin/mysql --user="debian-sys-maint" ' + \
+      .with('/usr/bin/mysql --user="debian-sys-maint" '\
             '--password="please-change-me" -r -B -N -e "SELECT 1"')
     expect(chef_run).to_not run_execute('correct-debian-grants')
   end
@@ -102,7 +101,7 @@ describe 'debian::mariadb::galera10-rsync' do
   context 'debian-sys-maint is not good' do
     let(:shellout) do
       double(run_command: nil, error!: true, error?: true,
-             stdout: 'ERROR 1045 (28000): Access denied for user ' + \
+             stdout: 'ERROR 1045 (28000): Access denied for user '\
                '\'debian-sys-maint\'@\'localhost\' (using password: YES)',
              stderr: double(empty?: false), exitstatus: 1,
              :live_stream= => nil)
@@ -118,10 +117,9 @@ end
 
 describe 'debian::mariadb::galera10-xtrabackup' do
   let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(
-                                   platform: 'debian', version: '7.4',
-                                   step_into: ['mariadb_configuration']
-                                 ) do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'debian', version: '7.4',
+                                      step_into: ['mariadb_configuration']
+                                     ) do |node|
       node.automatic['memory']['total'] = '2048kB'
       node.automatic['ipaddress'] = '1.1.1.1'
       node.set['mariadb']['galera']['wsrep_sst_method'] = 'xtrabackup'

--- a/spec/debian_galera55_spec.rb
+++ b/spec/debian_galera55_spec.rb
@@ -2,10 +2,9 @@ require 'spec_helper'
 
 describe 'debian::mariadb::galera55' do
   let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(
-                                   platform: 'debian', version: '7.4',
-                                   step_into: ['mariadb_configuration']
-                                 ) do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'debian', version: '7.4',
+                                      step_into: ['mariadb_configuration']
+                                     ) do |node|
       node.automatic['memory']['total'] = '2048kB'
       node.automatic['ipaddress'] = '1.1.1.1'
       node.set['mariadb']['install']['version'] = '5.5'

--- a/spec/debian_spec.rb
+++ b/spec/debian_spec.rb
@@ -9,10 +9,9 @@ describe 'debian::mariadb::default' do
   end
 
   let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(
-                                   platform: 'debian', version: '7.4',
-                                   step_into: ['mariadb_configuration']
-                                 ) do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'debian', version: '7.4',
+                                      step_into: ['mariadb_configuration']
+                                     ) do |node|
       node.automatic['memory']['total'] = '2048kB'
       node.automatic['ipaddress'] = '1.1.1.1'
     end
@@ -84,10 +83,9 @@ end
 
 describe 'debian::mariadb::client' do
   let(:chef_run) do
-    runner = ChefSpec::SoloRunner.new(
-                                   platform: 'debian', version: '7.4',
-                                   step_into: ['mariadb_configuration']
-                                 ) do |node|
+    runner = ChefSpec::SoloRunner.new(platform: 'debian', version: '7.4',
+                                      step_into: ['mariadb_configuration']
+                                     ) do |node|
       node.automatic['memory']['total'] = '2048kB'
       node.automatic['ipaddress'] = '1.1.1.1'
     end
@@ -103,10 +101,9 @@ describe 'debian::mariadb::client' do
   end
   context 'Without development files' do
     let(:chef_run) do
-      runner = ChefSpec::SoloRunner.new(
-                                     platform: 'debian', version: '7.4',
-                                     step_into: ['mariadb_configuration']
-                                   ) do |node|
+      runner = ChefSpec::SoloRunner.new(platform: 'debian', version: '7.4',
+                                        step_into: ['mariadb_configuration']
+                                       ) do |node|
         node.automatic['memory']['total'] = '2048kB'
         node.automatic['ipaddress'] = '1.1.1.1'
         node.set['mariadb']['client']['development_files'] = false

--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -12,11 +12,13 @@ describe MariaDB::Helper do
       end
 
       it 'return false' do
-        expect(dummy_helper.mariadb_service_restart_required?(
-          '127.0.0.1',
-          3306,
-          '/tmp/mysql.sock'
-        )).to be false
+        expect(
+          dummy_helper.mariadb_service_restart_required?(
+            '127.0.0.1',
+            3306,
+            '/tmp/mysql.sock'
+          )
+        ).to be false
       end
     end
 
@@ -29,11 +31,135 @@ describe MariaDB::Helper do
       end
 
       it 'return true' do
-        expect(dummy_helper.mariadb_service_restart_required?(
-          '127.0.0.1',
-          3306,
-          '/tmp/mysql.sock'
-        )).to be true
+        expect(
+          dummy_helper.mariadb_service_restart_required?(
+            '127.0.0.1',
+            3306,
+            '/tmp/mysql.sock'
+          )
+        ).to be true
+      end
+    end
+  end
+
+  describe '#use_os_native_package?' do
+    let(:dummy_class) { Class.new { include MariaDB::Helper } }
+    let(:dummy_helper) { dummy_class.new }
+
+    context 'os package provided' do
+      let(:support_platforms) do
+        Hash['redhat' => %w(7.0 7.1),
+             'centos' => %w(7.0),
+             'fedora' => %w(19 20 21)
+        ]
+      end
+
+      it 'os_package_provided to be true' do
+        support_platforms.each do |platform, ver_list|
+          ver_list.each do |version|
+            expect(
+              dummy_helper.os_package_provided?(
+                platform, version
+              )
+            ).to be true
+          end
+        end
+      end
+
+      it 'use native package' do
+        support_platforms.each do |platform, ver_list|
+          ver_list.each do |version|
+            expect(
+              dummy_helper.use_os_native_package?(
+                true, platform, version
+              )
+            ).to be true
+            expect(
+              dummy_helper.use_os_native_package?(
+                false, platform, version
+              )
+            ).to be false
+          end
+        end
+      end
+
+      it 'native os service name' do
+        support_platforms.each do |platform, ver_list|
+          ver_list.each do |version|
+            if platform == 'fedora' && version == '19'
+              expect(
+                dummy_helper.os_service_name(
+                  platform, version
+                )
+              ).to eq 'mysqld'
+            else
+              expect(
+                dummy_helper.os_service_name(
+                  platform, version
+                )
+              ).to eq 'mariadb'
+            end
+          end
+        end
+      end
+    end
+
+    context 'os package not provided' do
+      let(:unsupport_platforms) do
+        Hash['redhat' => %w(5.5 6.4 6.5),
+             'centos' => %w(5.4 6.6),
+             'fedora' => %w(17 18),
+             'ubuntu' => %w(11.04 12.04 14.04),
+             'debian' => %w(7.8)
+        ]
+      end
+
+      it 'os_package_provided to be false' do
+        unsupport_platforms.each do |platform, ver_list|
+          ver_list.each do |version|
+            expect(
+              dummy_helper.os_package_provided?(
+                platform, version
+              )
+            ).to be false
+          end
+        end
+      end
+
+      it 'cannot use native package' do
+        warn_called = false
+        allow(Chef::Log).to receive(:warn) { warn_called = true }
+        unsupport_platforms.each do |platform, ver_list|
+          ver_list.each do |version|
+            warn_called = false
+            expect(
+              dummy_helper.use_os_native_package?(
+                true, platform, version
+              )
+            ).to be false
+            expect(warn_called).to be true
+
+            warn_called = false
+            expect(
+              dummy_helper.use_os_native_package?(
+                false, platform, version
+              )
+            ).to be false
+            expect(warn_called).to be false
+          end
+        end
+      end
+
+      it 'no native os service name' do
+        unsupport_platforms.each do |platform, ver_list|
+          ver_list.each do |version|
+            expect(
+              dummy_helper.os_service_name(
+                platform, version
+              )
+            ).to eq nil
+          end
+        end
       end
     end
   end

--- a/templates/default/mariadb_grants.erb
+++ b/templates/default/mariadb_grants.erb
@@ -12,7 +12,7 @@
 <% end -%>
 password_flag=""
 if [ "$1" ]; then
-  password_flag="-p'$1'"
+  password_flag="-p$1"
 fi
 
 <% if node['mariadb']['forbid_remote_root'] -%>

--- a/test/integration/plugins/serverspec/mariadb_spec.rb
+++ b/test/integration/plugins/serverspec/mariadb_spec.rb
@@ -9,9 +9,9 @@ describe port('3306') do
   it { should be_listening }
 end
 
-describe command('/usr/bin/mysql -u root -B -N -e "SELECT 1 ' + \
-                  'FROM information_schema.plugins ' + \
-                  'WHERE PLUGIN_NAME = \"SERVER_AUDIT\"' + \
+describe command('/usr/bin/mysql -u root -B -N -e "SELECT 1 '\
+                  'FROM information_schema.plugins '\
+                  'WHERE PLUGIN_NAME = \"SERVER_AUDIT\"'\
                   'AND PLUGIN_STATUS = \"ACTIVE\""') do
   its(:stdout)  { should match(/^1$/) }
 end


### PR DESCRIPTION
1. Create a new recipe to use os natively shipped packages for mariadb
2. Add a helper function to determine which platforms has shipped
   mariadb.
3. Fix an issue running mariadb_grants with remote access allowed.
4. With rubocop updated in v0.29.0, fix indent issues with new style.
