### PR TITLE
Mapping platform 'redhat' to 'rhel' for redhat platform

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -21,10 +21,15 @@ if node['mariadb']['use_default_repository']
   when 'yum'
     include_recipe 'yum::default'
 
+    if node['platform'] == 'redhat'
+      target_platform = "rhel#{node['platform_version'].to_i}"
+    else
+      target_platform = "#{node['platform']}#{node['platform_version'].to_i}"
+    end
     yum_repository "mariadb-#{node['mariadb']['install']['version']}" do
       description 'MariaDB Official Repository'
       baseurl 'http://yum.mariadb.org/' + \
-        node['mariadb']['install']['version'] + "/#{node['platform']}#{node['platform_version'].to_i}-amd64"
+        node['mariadb']['install']['version'] + "/#{target_platform}-amd64"
       gpgkey 'https://yum.mariadb.org/RPM-GPG-KEY-MariaDB'
       action :create
     end


### PR DESCRIPTION
Default yum repo of mariadb on http://yum.mariadb.org/ uses 'rhel' for redhat platform, for example: http://yum.mariadb.org/10.0/rhel7-amd64/ but ohai returns node['platform'] as 'redhat'. Needs to do the mapping in repository.rb
