### PR TITLE
Mapping platform 'redhat' to 'rhel' for redhat platform

### DIFF
--- a/recipes/_redhat_galera.rb
+++ b/recipes/_redhat_galera.rb
@@ -17,11 +17,10 @@
 # limitations under the License.
 #
 
-#To force removing of mariadb-libs on CentOS >= 7
+# To force removing of mariadb-libs on CentOS >= 7
 package 'MariaDB-shared' do
-  action:install
+  action :install
 end
-
 
 package 'MariaDB-Galera-server' do
   action :install

--- a/recipes/_redhat_server.rb
+++ b/recipes/_redhat_server.rb
@@ -17,9 +17,9 @@
 # limitations under the License.
 #
 
-#To force removing of mariadb-libs on CentOS >= 7
+# To force removing of mariadb-libs on CentOS >= 7
 package 'MariaDB-shared' do
-  action:install
+  action :install
 end
 
 package 'MariaDB-server' do

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -21,10 +21,15 @@ if node['mariadb']['use_default_repository']
   when 'yum'
     include_recipe 'yum::default'
 
+    if node['platform'] == 'redhat'
+      target_platform = "rhel#{node['platform_version'].to_i}"
+    else
+      target_platform = "#{node['platform']}#{node['platform_version'].to_i}"
+    end
     yum_repository "mariadb-#{node['mariadb']['install']['version']}" do
       description 'MariaDB Official Repository'
       baseurl 'http://yum.mariadb.org/' + \
-        node['mariadb']['install']['version'] + "/#{node['platform']}#{node['platform_version'].to_i}-amd64"
+        node['mariadb']['install']['version'] + "/#{target_platform}-amd64"
       gpgkey 'https://yum.mariadb.org/RPM-GPG-KEY-MariaDB'
       action :create
     end


### PR DESCRIPTION
Default yum repo of mariadb on http://yum.mariadb.org/ uses 'rhel' for redhat platform, for example: http://yum.mariadb.org/10.0/rhel7-amd64/ but ohai returns node['platform'] as 'redhat'. Needs to do the mapping in repository.rb

Fix some rubocop issues.
