### PR TITLE
Add user and password to correct-debian-grants

### DIFF
--- a/recipes/galera.rb
+++ b/recipes/galera.rb
@@ -118,14 +118,15 @@ if platform?('debian', 'ubuntu')
 
   execute 'correct-debian-grants' do
     # Add sensitive true when foodcritic #233 fixed
-    command 'mysql -r -B -N -e "GRANT SELECT, INSERT, UPDATE, DELETE, '\
-      'CREATE, DROP, RELOAD, SHUTDOWN, PROCESS, FILE, REFERENCES, INDEX, '\
-      'ALTER, SHOW DATABASES, SUPER, CREATE TEMPORARY TABLES, '\
-      'LOCK TABLES, EXECUTE, REPLICATION SLAVE, REPLICATION CLIENT, '\
-      'CREATE VIEW, SHOW VIEW, CREATE ROUTINE, ALTER ROUTINE, '\
-      "CREATE USER, EVENT, TRIGGER ON *.* TO '" + \
-      node['mariadb']['debian']['user'] + \
-      "'@'" + node['mariadb']['debian']['host'] + "' IDENTIFIED BY '" + \
+    command "mysql -r -B -N -u root "\
+      "--password='" + node['mariadb']['server_root_password'] + "' -e " \
+      "\"GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, RELOAD, " \
+      "SHUTDOWN, PROCESS, FILE, REFERENCES, INDEX, ALTER, SHOW DATABASES, " \
+      "SUPER, CREATE TEMPORARY TABLES, LOCK TABLES, EXECUTE, REPLICATION " \
+      "SLAVE, REPLICATION CLIENT, CREATE VIEW, SHOW VIEW, CREATE ROUTINE, " \
+      "ALTER ROUTINE, CREATE USER, EVENT, TRIGGER ON *.* TO " \
+      "'" + node['mariadb']['debian']['user'] + "'@'" + \
+      node['mariadb']['debian']['host'] + "' IDENTIFIED BY '" + \
       node['mariadb']['debian']['password'] + "' WITH GRANT OPTION\""
     action :run
     only_if do


### PR DESCRIPTION
This corrects an issue that arises with the command that sets the debian-sys-maint user's password when the root user has a password set.
