### PR TITLE
Fix native package installation issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ mariadb CHANGELOG
 
 This file is used to list changes made in each version of the mariadb cookbook.
 
+0.3.1
+------
+- [BUG] - Fix operating system shipped package installation issue
+
 0.3.0
 ------
 - [ENH] - Add support for using operating system shipped mariadb packages

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'sinfomicien@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures MariaDB'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '0.3.0'
+version '0.3.1'
 
 supports 'ubuntu'
 supports 'debian', '>= 7.0'

--- a/recipes/_redhat_server_native.rb
+++ b/recipes/_redhat_server_native.rb
@@ -23,7 +23,7 @@ node.set['mariadb']['mysqld']['service_name'] = service_name\
   unless service_name.nil?
 
 directory '/var/log/mysql' do
-  action :create
+  action :nothing
   user 'mysql'
   group 'mysql'
   mode '0755'
@@ -31,6 +31,7 @@ end
 
 package 'mariadb-server' do
   action :install
+  notifies :create, 'directory[/var/log/mysql]', :immediately
   notifies :enable, 'service[mysql]'
   notifies :start, 'service[mysql]', :immediately
   notifies :run, 'execute[change first install root password]', :immediately

--- a/spec/centos_spec.rb
+++ b/spec/centos_spec.rb
@@ -80,11 +80,8 @@ describe 'centos::mariadb::native' do
 
     it 'Install os shipped package' do
       expect(chef_run).to install_package('mariadb-server')
+      expect(os_package).to notify('directory[/var/log/mysql]').to(:create).immediately
       expect(os_package).to notify('service[mysql]').to(:start).immediately
-    end
-
-    it 'Create Log directory' do
-      expect(chef_run).to create_directory('/var/log/mysql')
     end
 
     it 'Server service with the correct name' do


### PR DESCRIPTION
The directory /var/log/mysql should be notified to create after
mariadb-server was created. Otherwise, the system cannot find the
user/group mysql:mysql and the folder creation will fail
