### PR TITLE
Update repository.rb

### DIFF
--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -21,7 +21,7 @@ if node['mariadb']['use_default_repository']
   when 'yum'
     include_recipe 'yum::default'
 
-    if node['platform'] == 'redhat'
+    if node['platform'] == 'redhat' || node['platform'] == 'scientific'
       target_platform = "rhel#{node['platform_version'].to_i}"
     else
       target_platform = "#{node['platform']}#{node['platform_version'].to_i}"
@@ -35,7 +35,7 @@ if node['mariadb']['use_default_repository']
     end
 
     case node['platform']
-    when 'redhat', 'centos'
+    when 'redhat', 'centos', 'scientific'
       include_recipe 'yum-epel::default'
     end
   end


### PR DESCRIPTION
Since node['platform'] == 'scientific', it generates a baseurl of "http://yum.mariadb.org/10.0/scientific7-amd64".
This does not exist. The next best match would be to use rhel.
