### PR TITLE
Fix directory permissions regression

### DIFF
--- a/recipes/_redhat_server_native.rb
+++ b/recipes/_redhat_server_native.rb
@@ -22,16 +22,16 @@ service_name = os_service_name(node['platform'], node['platform_version'])
 node.set['mariadb']['mysqld']['service_name'] = service_name\
   unless service_name.nil?
 
+package 'mariadb-server' do
+  action :install
+  notifies :enable, 'service[mysql]'
+end
+
 directory '/var/log/mysql' do
   action :create
   user 'mysql'
   group 'mysql'
   mode '0755'
-end
-
-package 'mariadb-server' do
-  action :install
-  notifies :enable, 'service[mysql]'
   notifies :start, 'service[mysql]', :immediately
   notifies :run, 'execute[change first install root password]', :immediately
 end

--- a/spec/centos_spec.rb
+++ b/spec/centos_spec.rb
@@ -80,11 +80,14 @@ describe 'centos::mariadb::native' do
 
     it 'Install os shipped package' do
       expect(chef_run).to install_package('mariadb-server')
-      expect(os_package).to notify('service[mysql]').to(:start).immediately
     end
 
     it 'Create Log directory' do
       expect(chef_run).to create_directory('/var/log/mysql')
+    end
+
+    it 'Does not restart mysql service' do
+      expect(chef_run).to_not restart_service('mysql')
     end
 
     it 'Server service with the correct name' do


### PR DESCRIPTION
Due to recipe ordering, /var/log/mysql does not get the correct permissions applied before the mariadb-server package gets installed, resulting in a scenario where MariaDB will not start.
