### PR TITLE
adding the ability to specify the key and keyserver for an apt repo

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -143,9 +143,9 @@ default['mariadb']['install']['prefer_os_package'] = false
 # package(apt or yum) default configuration
 #
 default['mariadb']['use_default_repository'] = false
-default['mariadb']['apt_repository']['base_url'] = \
-  'ftp.igh.cnrs.fr/pub/mariadb/repo'
-
+default['mariadb']['apt_repository']['base_url'] = 'nyc2.mirrors.digitalocean.com/mariadb/repo/'
+default['mariadb']['apt_repository']['key'] ="0xcbcb082a1bb943db"
+default['mariadb']['apt_repository']['keyserver'] ="hkp://keyserver.ubuntu.com:80"
 #
 # MariaDB Plugins enabling
 #

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -15,8 +15,8 @@ if node['mariadb']['use_default_repository']
         node['mariadb']['install']['version'] + '/' + node['platform']
       distribution node['lsb']['codename']
       components ['main']
-      keyserver 'hkp://keyserver.ubuntu.com:80'
-      key '0xcbcb082a1bb943db'
+      keyserver node['mariadb']['apt_repository']['keyserver']
+      key node['mariadb']['apt_repository']['key']
     end
   when 'yum'
     include_recipe 'yum::default'


### PR DESCRIPTION
This allows a user to specify which key and keyserver they would like to use to sign their packages.

Also, we use a standard mariadb PPA instead of ftp.igh.cnrs.fr, which has a tendency to go down every once and a while.
