### PR TITLE
Remove anonymous users and test database by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,6 +18,8 @@ end
 #
 # mysqld default configuration
 #
+default['mariadb']['remove_anonymous_users']            = true
+default['mariadb']['remove_test_database']              = true
 default['mariadb']['forbid_remote_root']                = true
 default['mariadb']['server_root_password']              = ''
 default['mariadb']['allow_root_pass_change']            = false

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -107,7 +107,9 @@ if node['mariadb']['allow_root_pass_change']
 end
 
 if  node['mariadb']['allow_root_pass_change'] ||
-    node['mariadb']['forbid_remote_root']
+    node['mariadb']['remove_anonymous_users'] ||
+    node['mariadb']['forbid_remote_root'] ||
+    node['mariadb']['remove_test_database']
   execute 'install-grants' do
     # Add sensitive true when foodcritic #233 fixed
     command '/bin/bash /etc/mariadb_grants \'' + \

--- a/templates/default/mariadb_grants.erb
+++ b/templates/default/mariadb_grants.erb
@@ -15,6 +15,10 @@ if [ "$1" ]; then
   password_flag="-p$1"
 fi
 
+<% if node['mariadb']['remove_anonymous_users'] -%>
+/bin/echo "DELETE FROM mysql.user WHERE User='';" | /usr/bin/mysql -u root ${password_flag}
+<% end -%>
+
 <% if node['mariadb']['forbid_remote_root'] -%>
 user_exist=`/usr/bin/mysql -u root ${password_flag} -D mysql -r -B -N -e "SELECT user from user where user = 'root' and host = '%'"`
 if [ $user_exist == 'root' ]; then
@@ -23,3 +27,9 @@ fi
 <% else -%>
 /bin/echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY '<%= node['mariadb']['server_root_password'] %>' WITH GRANT OPTION;" | /usr/bin/mysql -u root ${password_flag}
 <% end -%>
+
+<% if node['mariadb']['remove_test_database'] -%>
+/bin/echo "DROP DATABASE IF EXISTS test; DELETE FROM mysql.db WHERE Db='test' OR Db='test\\_%';" | /usr/bin/mysql -u root ${password_flag}
+<% end -%>
+
+/bin/echo "FLUSH PRIVILEGES;" | /usr/bin/mysql -u root ${password_flag}


### PR DESCRIPTION
Partially addresses issue #14.

This now reflects the mariadb_secure_installation script. It's reasonable to assume that one would want anonymous users and the test database removed by default.
