### PR TITLE
Add sensitive attribute to execute statement

### DIFF
--- a/recipes/galera.rb
+++ b/recipes/galera.rb
@@ -153,6 +153,7 @@ if platform?('debian', 'ubuntu')
       cmd.error?
     end
     ignore_failure true
+	sensitive true
   end
 end
 


### PR DESCRIPTION
The root and debian-sys-maint user's credentials are currently displayed in the output of chef-client. Adding the sensitive attribute to the execute resource suppresses that output.
