### PR TITLE
Fixed tab to spaces

### DIFF
--- a/recipes/galera.rb
+++ b/recipes/galera.rb
@@ -153,7 +153,7 @@ if platform?('debian', 'ubuntu')
       cmd.error?
     end
     ignore_failure true
-	sensitive true
+    sensitive true
   end
 end
 


### PR DESCRIPTION
Had a bad tab instead of spaces in the previous pull request. Thanks, vim.
