### PR TITLE
data_bag and MariaDB 10.1 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.1.5
+- 2.1.7
 bundler_args: --without development
 gemfile:
 - Gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,7 @@ group :packaging do
 end
 
 group :unit do
-  gem 'berkshelf', '~> 3.1'
+  gem 'berkshelf', '~> 4.0'
   gem 'chefspec', '~> 4.2'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'ohai', '7.4.1'
 gem 'chef', '~>11.16'
 
 group :lint do
-  gem 'foodcritic', '~> 4.0'
+  gem 'foodcritic', '~> 5.0'
   gem 'rubocop', '~> 0.30'
   gem 'rainbow', '< 2.0'
   gem 'rspec'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -81,9 +81,14 @@ default['mariadb']['innodb']['options']                = {}
 #
 default['mariadb']['galera']['cluster_name'] = 'galera_cluster'
 default['mariadb']['galera']['cluster_search_query'] = ''
-default['mariadb']['galera']['wsrep_sst_method']   = 'rsync'
+default['mariadb']['galera']['wsrep_sst_method']   = 'xtrabackup-v2'
+default['mariadb']['galera']['wsrep_sst_auth']     = 'sstuser:some_secret_password'
 default['mariadb']['galera']['wsrep_provider']     = \
   '/usr/lib/galera/libgalera_smm.so'
+default['mariadb']['galera']['wsrep_slave_threads'] = '4'
+default['mariadb']['galera']['wsrep_node_address_interface'] = ''    #         node[:network][:interfaces][:eth1][:address][:inet]
+default['mariadb']['galera']['wsrep_node_incoming_address_interface'] = ''
+default['mariadb']['galera']['wsrep_provider_options'] = {}
 default['mariadb']['galera']['options']            = {}
 
 # Node format: [{ :name => "mariadb_1", fqdn: "33.33.33.11"}]

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -20,17 +20,19 @@ end
 #
 default['mariadb']['forbid_remote_root']                = true
 default['mariadb']['server_root_password']              = ''
+default['mariadb']['root_my_cnf']                       = false
 default['mariadb']['allow_root_pass_change']            = false
 if node['platform'] == 'centos'
   default['mariadb']['mysqld']['service_name']          = 'mariadb'
 else
-  default['mariadb']['mysqld']['service_name']            = 'mysql'
+  default['mariadb']['mysqld']['service_name']          = 'mysql'
 end
 default['mariadb']['mysqld']['user']                    = 'mysql'
 default['mariadb']['mysqld']['port']                    = '3306'
 default['mariadb']['mysqld']['basedir']                 = '/usr'
 default['mariadb']['mysqld']['default_datadir']         = '/var/lib/mysql'
 # if different from previous value, datadir will be moved after install
+# you will have to take care about apparmor/SELinux
 default['mariadb']['mysqld']['datadir']                 = '/var/lib/mysql'
 default['mariadb']['mysqld']['tmpdir']                  = '/var/tmp'
 default['mariadb']['mysqld']['lc_messages_dir']         = '/usr/share/mysql'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -81,14 +81,20 @@ default['mariadb']['innodb']['options']                = {}
 #
 default['mariadb']['galera']['cluster_name'] = 'galera_cluster'
 default['mariadb']['galera']['cluster_search_query'] = ''
+# All Galera nodes should get the same server_id
+default['mariadb']['galera']['server_id']          = '100'
 default['mariadb']['galera']['wsrep_sst_method']   = 'xtrabackup-v2'
 default['mariadb']['galera']['wsrep_sst_auth']     = 'sstuser:some_secret_password'
 default['mariadb']['galera']['wsrep_provider']     = \
   '/usr/lib/galera/libgalera_smm.so'
 default['mariadb']['galera']['wsrep_slave_threads'] = '4'
-default['mariadb']['galera']['wsrep_node_address_interface'] = ''    #         node[:network][:interfaces][:eth1][:address][:inet]
+# Default value is '1' but can be relaxed to '2' or even '0' with Galera
+default['mariadb']['galera']['innodb_flush_log_at_trx_commit'] = '2'
+default['mariadb']['galera']['wsrep_node_address_interface'] = ''
 default['mariadb']['galera']['wsrep_node_incoming_address_interface'] = ''
-default['mariadb']['galera']['wsrep_provider_options'] = {}
+default['mariadb']['galera']['wsrep_provider_options'] = {
+  'gcache.size' => '512M'
+}
 default['mariadb']['galera']['options']            = {}
 
 # Node format: [{ :name => "mariadb_1", fqdn: "33.33.33.11"}]
@@ -102,6 +108,8 @@ default['mariadb']['replication']['log_bin']          = \
   '/var/log/mysql/mariadb-bin'
 default['mariadb']['replication']['log_bin_index']    = \
   '/var/log/mysql/mariadb-bin.index'
+# Setting sync_binlog to 1 will cause a performance impact
+default['mariadb']['replication']['sync_binlog']      = '0'
 default['mariadb']['replication']['expire_logs_days'] = '10'
 default['mariadb']['replication']['max_binlog_size']  = '100M'
 default['mariadb']['replication']['options']          = {}

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -85,7 +85,7 @@ default['mariadb']['galera']['cluster_name'] = 'galera_cluster'
 default['mariadb']['galera']['cluster_search_query'] = ''
 # All Galera nodes should get the same server_id
 default['mariadb']['galera']['server_id']          = '100'
-default['mariadb']['galera']['wsrep_sst_method']   = 'xtrabackup-v2'
+default['mariadb']['galera']['wsrep_sst_method']   = 'rsync'
 default['mariadb']['galera']['wsrep_sst_auth']     = 'sstuser:some_secret_password'
 default['mariadb']['galera']['wsrep_provider']     = \
   '/usr/lib/galera/libgalera_smm.so'

--- a/providers/configuration.rb
+++ b/providers/configuration.rb
@@ -22,6 +22,7 @@ action :add do
     mode '0640'
     cookbook 'mariadb'
     variables variables_hash
+    sensitive true
   end
 end
 

--- a/recipes/_debian_galera.rb
+++ b/recipes/_debian_galera.rb
@@ -40,8 +40,8 @@ template '/var/cache/local/preseeding/mariadb-galera-server.seed' do
   owner 'root'
   group 'root'
   mode '0600'
-  variables(package_name: 'mariadb-galera-server')
-  notifies :run, 'execute[preseed mariadb-galera-server]', :immediately
+  variables(:package_name => 'mariadb-server')
+    notifies :run, 'execute[preseed mariadb-galera-server]', :immediately
 end
 
 execute 'preseed mariadb-galera-server' do
@@ -50,6 +50,15 @@ execute 'preseed mariadb-galera-server' do
   action :nothing
 end
 
-package "mariadb-galera-server-#{node['mariadb']['install']['version']}" do
-  action :install
+if node['mariadb']['install']['version'].to_f < 10.1
+  package "mariadb-galera-server-#{node['mariadb']['install']['version']}" do
+    action :install
+  end
+  package "pv" do
+    action :install
+  end
+else
+  package "mariadb-server-#{node['mariadb']['install']['version']}" do
+    action :install
+  end
 end

--- a/recipes/_debian_galera.rb
+++ b/recipes/_debian_galera.rb
@@ -40,7 +40,7 @@ template '/var/cache/local/preseeding/mariadb-galera-server.seed' do
   owner 'root'
   group 'root'
   mode '0600'
-  variables(:package_name => 'mariadb-server')
+  variables(package_name: 'mariadb-server')
   notifies :run, 'execute[preseed mariadb-galera-server]', :immediately
   sensitive true
 end

--- a/recipes/_debian_galera.rb
+++ b/recipes/_debian_galera.rb
@@ -41,7 +41,8 @@ template '/var/cache/local/preseeding/mariadb-galera-server.seed' do
   group 'root'
   mode '0600'
   variables(:package_name => 'mariadb-server')
-    notifies :run, 'execute[preseed mariadb-galera-server]', :immediately
+  notifies :run, 'execute[preseed mariadb-galera-server]', :immediately
+  sensitive true
 end
 
 execute 'preseed mariadb-galera-server' do
@@ -52,9 +53,6 @@ end
 
 if node['mariadb']['install']['version'].to_f < 10.1
   package "mariadb-galera-server-#{node['mariadb']['install']['version']}" do
-    action :install
-  end
-  package "pv" do
     action :install
   end
 else

--- a/recipes/_debian_server.rb
+++ b/recipes/_debian_server.rb
@@ -17,18 +17,20 @@
 # limitations under the License.
 #
 
-exist_data_bag_mariadb_root = search(:mariadb, "id:user_root").first
+if Chef::Config[:solo]
+  Chef::Log.warn('This recipe uses search. Chef Solo does not support search.')
+else
+  exist_data_bag_mariadb_root = search(:mariadb, 'id:user_root').first
+  unless exist_data_bag_mariadb_root.nil?
+    data_bag_mariadb_root = data_bag_item('mariadb', 'user_root')
+    node.override['mariadb']['server_root_password'] = data_bag_mariadb_root['password']
+  end
 
-unless exist_data_bag_mariadb_root.nil?
-  data_bag_mariadb_root = data_bag_item('mariadb', 'user_root')
-  node.override['mariadb']['server_root_password'] = data_bag_mariadb_root['password']
-end
-
-exist_data_bag_mariadb_debian = search(:mariadb, "id:user_debian").first
-
-unless exist_data_bag_mariadb_debian.nil?
-  data_bag_mariadb_debian = data_bag_item('mariadb', 'user_debian')
-  node.override['mariadb']['debian']['password'] = data_bag_mariadb_debian['password']
+  exist_data_bag_mariadb_debian = search(:mariadb, 'id:user_debian').first
+  unless exist_data_bag_mariadb_debian.nil?
+    data_bag_mariadb_debian = data_bag_item('mariadb', 'user_debian')
+    node.override['mariadb']['debian']['password'] = data_bag_mariadb_debian['password']
+  end
 end
 
 # To be sure that debconf is installed
@@ -54,7 +56,7 @@ template '/var/cache/local/preseeding/mariadb-server.seed' do
   owner 'root'
   group 'root'
   mode '0600'
-  variables(:package_name => 'mariadb-server')
+  variables(package_name: 'mariadb-server')
   notifies :run, 'execute[preseed mariadb-server]', :immediately
   sensitive true
 end

--- a/recipes/_debian_server.rb
+++ b/recipes/_debian_server.rb
@@ -17,6 +17,20 @@
 # limitations under the License.
 #
 
+exist_data_bag_mariadb_root = search(:mariadb, "id:user_root").first
+
+unless exist_data_bag_mariadb_root.nil?
+  data_bag_mariadb_root = data_bag_item('mariadb', 'user_root')
+  node.override['mariadb']['server_root_password'] = data_bag_mariadb_root['password']
+end
+
+exist_data_bag_mariadb_debian = search(:mariadb, "id:user_debian").first
+
+unless exist_data_bag_mariadb_debian.nil?
+  data_bag_mariadb_debian = data_bag_item('mariadb', 'user_debian')
+  node.override['mariadb']['debian']['password'] = data_bag_mariadb_debian['password']
+end
+
 # To be sure that debconf is installed
 package 'debconf-utils' do
   action :install
@@ -40,8 +54,8 @@ template '/var/cache/local/preseeding/mariadb-server.seed' do
   owner 'root'
   group 'root'
   mode '0600'
-  variables(package_name: 'mariadb-server')
-  notifies :run, 'execute[preseed mariadb-server]', :immediately
+  variables(:package_name => 'mariadb-server')
+    notifies :run, 'execute[preseed mariadb-server]', :immediately
 end
 
 execute 'preseed mariadb-server' do

--- a/recipes/_debian_server.rb
+++ b/recipes/_debian_server.rb
@@ -55,7 +55,8 @@ template '/var/cache/local/preseeding/mariadb-server.seed' do
   group 'root'
   mode '0600'
   variables(:package_name => 'mariadb-server')
-    notifies :run, 'execute[preseed mariadb-server]', :immediately
+  notifies :run, 'execute[preseed mariadb-server]', :immediately
+  sensitive true
 end
 
 execute 'preseed mariadb-server' do

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-if ['mariadb']['root_my_cnf']
+if node['mariadb']['root_my_cnf']
   template '/root/.my.cnf' do
     source 'root.cnf.erb'
     owner 'root'

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -75,6 +75,8 @@ end
 replication_opts = {}
 
 replication_opts['log_bin'] = node['mariadb']['replication']['log_bin']
+replication_opts['sync_binlog'] = \
+  node['mariadb']['replication']['sync_binlog']
 replication_opts['log_bin_index']    = \
   node['mariadb']['replication']['log_bin_index']
 replication_opts['expire_logs_days'] = \

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -17,13 +17,12 @@
 # limitations under the License.
 #
 
-if node['mariadb']['root_my_cnf']
-  template '/root/.my.cnf' do
-    source 'root.cnf.erb'
-    owner 'root'
-    group 'root'
-    mode '0600'
-  end
+template '/root/.my.cnf' do
+  source 'root.cnf.erb'
+  owner 'root'
+  group 'root'
+  mode '0600'
+  only_if node['mariadb']['root_my_cnf']
 end
 
 template node['mariadb']['configuration']['path'] + '/my.cnf' do
@@ -47,7 +46,7 @@ innodb_options['innodb_log_file_size_comment1'] = '# you can\'t just ' \
   'change log file size, ' \
   'requires special procedure'
 if node['mariadb']['innodb']['log_file_size'].empty?
-  innodb_options['innodb_log_file_size']  = '#innodb_log_file_size   = 50M'
+  innodb_options['innodb_log_file_size'] = '#innodb_log_file_size = 50M'
 else
   innodb_options['innodb_log_file_size'] = \
     node['mariadb']['innodb']['log_file_size']

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -22,7 +22,7 @@ template '/root/.my.cnf' do
   owner 'root'
   group 'root'
   mode '0600'
-  only_if node['mariadb']['root_my_cnf']
+  only_if { node['mariadb']['root_my_cnf'] }
 end
 
 template node['mariadb']['configuration']['path'] + '/my.cnf' do

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -66,7 +66,7 @@ node['mariadb']['innodb']['options'].each do |key, value|
   innodb_options[key] = value
 end
 
-mariadb_configuration 'innodb' do
+mariadb_configuration '20-innodb' do
   section 'mysqld'
   option innodb_options
   action :add
@@ -88,7 +88,7 @@ node['mariadb']['replication']['options'].each do |key, value|
   replication_opts[key] = value
 end
 
-mariadb_configuration 'replication' do
+mariadb_configuration '30-replication' do
   section 'mysqld'
   option replication_opts
   action :add

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -17,6 +17,15 @@
 # limitations under the License.
 #
 
+if ['mariadb']['root_my_cnf']
+  template '/root/.my.cnf' do
+    source 'root.cnf.erb'
+    owner 'root'
+    group 'root'
+    mode '0600'
+  end
+end
+
 template node['mariadb']['configuration']['path'] + '/my.cnf' do
   source 'my.cnf.erb'
   owner 'root'
@@ -58,9 +67,9 @@ innodb_options['innodb_log_buffer_size'] = \
 innodb_options['innodb_file_per_table']  = \
   node['mariadb']['innodb']['file_per_table']
 innodb_options['innodb_open_files'] = node['mariadb']['innodb']['open_files']
-innodb_options['innodb_io_capacity']   = \
+innodb_options['innodb_io_capacity'] = \
   node['mariadb']['innodb']['io_capacity']
-innodb_options['innodb_flush_method']  = \
+innodb_options['innodb_flush_method'] = \
   node['mariadb']['innodb']['flush_method']
 node['mariadb']['innodb']['options'].each do |key, value|
   innodb_options[key] = value
@@ -77,11 +86,11 @@ replication_opts = {}
 replication_opts['log_bin'] = node['mariadb']['replication']['log_bin']
 replication_opts['sync_binlog'] = \
   node['mariadb']['replication']['sync_binlog']
-replication_opts['log_bin_index']    = \
+replication_opts['log_bin_index'] = \
   node['mariadb']['replication']['log_bin_index']
 replication_opts['expire_logs_days'] = \
   node['mariadb']['replication']['expire_logs_days']
-replication_opts['max_binlog_size']  = \
+replication_opts['max_binlog_size'] = \
   node['mariadb']['replication']['max_binlog_size']
 unless node['mariadb']['replication']['server_id'].empty?
   replication_opts['server-id'] = node['mariadb']['replication']['server_id']

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,18 +17,22 @@
 # limitations under the License.
 #
 
-exist_data_bag_mariadb_root = search(:mariadb, "id:user_root").first
+if Chef::Config[:solo]
+  Chef::Log.warn('This recipe uses search. Chef Solo does not support search.')
+else
+  exist_data_bag_mariadb_root = search(:mariadb, 'id:user_root').first
 
-unless exist_data_bag_mariadb_root.nil?
-  data_bag_mariadb_root = data_bag_item('mariadb', 'user_root')
-  node.override['mariadb']['server_root_password'] = data_bag_mariadb_root['password']
-end
+  unless exist_data_bag_mariadb_root.nil?
+    data_bag_mariadb_root = data_bag_item('mariadb', 'user_root')
+    node.override['mariadb']['server_root_password'] = data_bag_mariadb_root['password']
+  end
 
-exist_data_bag_mariadb_debian = search(:mariadb, "id:user_debian").first
+  exist_data_bag_mariadb_debian = search(:mariadb, 'id:user_debian').first
 
-unless exist_data_bag_mariadb_debian.nil?
-  data_bag_mariadb_debian = data_bag_item('mariadb', 'user_debian')
-  node.override['mariadb']['debian']['password'] = data_bag_mariadb_debian['password']
+  unless exist_data_bag_mariadb_debian.nil?
+    data_bag_mariadb_debian = data_bag_item('mariadb', 'user_debian')
+    node.override['mariadb']['debian']['password'] = data_bag_mariadb_debian['password']
+  end
 end
 
 include_recipe "#{cookbook_name}::server"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,4 +17,18 @@
 # limitations under the License.
 #
 
+exist_data_bag_mariadb_root = search(:mariadb, "id:user_root").first
+
+unless exist_data_bag_mariadb_root.nil?
+  data_bag_mariadb_root = data_bag_item('mariadb', 'user_root')
+  node.override['mariadb']['server_root_password'] = data_bag_mariadb_root['password']
+end
+
+exist_data_bag_mariadb_debian = search(:mariadb, "id:user_debian").first
+
+unless exist_data_bag_mariadb_debian.nil?
+  data_bag_mariadb_debian = data_bag_item('mariadb', 'user_debian')
+  node.override['mariadb']['debian']['password'] = data_bag_mariadb_debian['password']
+end
+
 include_recipe "#{cookbook_name}::server"

--- a/recipes/galera.rb
+++ b/recipes/galera.rb
@@ -60,7 +60,7 @@ if node['mariadb']['galera']['wsrep_sst_method'] == 'rsync'
   end
 else
   if node['mariadb']['galera']['wsrep_sst_method'] =~ /^xtrabackup(-v2)?/
-    %w{percona-xtrabackup socat pv}.each do |pkg|
+    %w(percona-xtrabackup socat pv).each do |pkg|
       package pkg do
         action :install
       end

--- a/recipes/galera.rb
+++ b/recipes/galera.rb
@@ -60,7 +60,7 @@ if node['mariadb']['galera']['wsrep_sst_method'] == 'rsync'
   end
 else
   if node['mariadb']['galera']['wsrep_sst_method'] =~ /^xtrabackup(-v2)?/
-    %w{(percona-xtrabackup) (socat) (pv)}.each do |pkg|
+    %w{percona-xtrabackup socat pv}.each do |pkg|
       package pkg do
         action :install
       end

--- a/recipes/galera.rb
+++ b/recipes/galera.rb
@@ -60,7 +60,7 @@ if node['mariadb']['galera']['wsrep_sst_method'] == 'rsync'
   end
 else
   if node['mariadb']['galera']['wsrep_sst_method'] =~ /^xtrabackup(-v2)?/
-    %w{percona-xtrabackup socat pv}.each do |pkg|
+    %w{(percona-xtrabackup) (socat) (pv)}.each do |pkg|
       package pkg do
         action :install
       end
@@ -152,7 +152,7 @@ end
 unless node['mariadb']['galera']['wsrep_node_address_interface'].empty?
   ipaddress = ''
   iface = node['mariadb']['galera']['wsrep_node_address_interface']
-  node['network']['interfaces']["#{iface}"]['addresses'].each do |ip, params|
+  node['network']['interfaces'][iface]['addresses'].each do |ip, params|
     params['family'] == ('inet') && ipaddress = ip
   end
   galera_options['wsrep_node_address'] = ipaddress unless ipaddress.empty?
@@ -160,7 +160,7 @@ end
 unless node['mariadb']['galera']['wsrep_node_incoming_address_interface'].empty?
   ipaddress_inc = ''
   iface = node['mariadb']['galera']['wsrep_node_incoming_address_interface']
-  node['network']['interfaces']["#{iface}"]['addresses'].each do |ip, params|
+  node['network']['interfaces'][iface]['addresses'].each do |ip, params|
     params['family'] == ('inet') && ipaddress_inc = ip
   end
   galera_options['wsrep_node_incoming_address'] = \
@@ -210,7 +210,6 @@ if platform?('debian', 'ubuntu')
                     'OPTION"'
 
   execute 'correct-debian-grants' do
-    # Add sensitive true when foodcritic #233 fixed
     command grants_command
     action :run
     only_if do

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -127,4 +127,5 @@ if  node['mariadb']['allow_root_pass_change'] ||
 end
 
 # MariaDB Plugins
-include_recipe "#{cookbook_name}::plugins" if node['mariadb']['plugins_options']['auto_install']
+include_recipe "#{cookbook_name}::plugins" if \
+  node['mariadb']['plugins_options']['auto_install']

--- a/spec/centos_spec.rb
+++ b/spec/centos_spec.rb
@@ -21,16 +21,16 @@ describe 'centos::mariadb::default' do
       .with_content(%r{/etc/my.cnf.d})
   end
 
-  it 'Configure replication in /etc/my.cnf.d/replication.cnf' do
-    expect(chef_run).to create_template('/etc/my.cnf.d/replication.cnf')
+  it 'Configure replication in /etc/my.cnf.d/30-replication.cnf' do
+    expect(chef_run).to create_template('/etc/my.cnf.d/30-replication.cnf')
     expect(chef_run).to render_file('/etc/my.cnf.d/replication.cnf')
   end
 
   it 'Configure InnoDB with attributes' do
     expect(chef_run).to add_mariadb_configuration('innodb')
-    expect(chef_run).to render_file('/etc/my.cnf.d/innodb.cnf')
+    expect(chef_run).to render_file('/etc/my.cnf.d/20-innodb.cnf')
       .with_content(/innodb_buffer_pool_size = 256M/)
-    expect(chef_run).to create_template('/etc/my.cnf.d/innodb.cnf')
+    expect(chef_run).to create_template('/etc/my.cnf.d/20-innodb.cnf')
       .with(
         user:  'root',
         group: 'mysql',
@@ -39,7 +39,7 @@ describe 'centos::mariadb::default' do
   end
 
   it 'Configure Replication' do
-    expect(chef_run).to add_mariadb_configuration('replication')
+    expect(chef_run).to add_mariadb_configuration('30-replication')
   end
 
   it 'Don t execute root password change at install' do
@@ -119,16 +119,16 @@ describe 'centos::mariadb::native' do
       .with_content(%r{/etc/my.cnf.d})
   end
 
-  it 'Configure replication in /etc/my.cnf.d/replication.cnf' do
-    expect(chef_run).to create_template('/etc/my.cnf.d/replication.cnf')
-    expect(chef_run).to render_file('/etc/my.cnf.d/replication.cnf')
+  it 'Configure replication in /etc/my.cnf.d/30-replication.cnf' do
+    expect(chef_run).to create_template('/etc/my.cnf.d/30-replication.cnf')
+    expect(chef_run).to render_file('/etc/my.cnf.d/30-replication.cnf')
   end
 
   it 'Configure InnoDB with attributes' do
-    expect(chef_run).to add_mariadb_configuration('innodb')
-    expect(chef_run).to render_file('/etc/my.cnf.d/innodb.cnf')
+    expect(chef_run).to add_mariadb_configuration('20-innodb')
+    expect(chef_run).to render_file('/etc/my.cnf.d/20-innodb.cnf')
       .with_content(/innodb_buffer_pool_size = 256M/)
-    expect(chef_run).to create_template('/etc/my.cnf.d/innodb.cnf')
+    expect(chef_run).to create_template('/etc/my.cnf.d/20-innodb.cnf')
       .with(
         user:  'root',
         group: 'mysql',
@@ -137,7 +137,7 @@ describe 'centos::mariadb::native' do
   end
 
   it 'Configure Replication' do
-    expect(chef_run).to add_mariadb_configuration('replication')
+    expect(chef_run).to add_mariadb_configuration('30-replication')
   end
 
   it 'Don t execute root password change at install' do

--- a/spec/centos_spec.rb
+++ b/spec/centos_spec.rb
@@ -23,11 +23,11 @@ describe 'centos::mariadb::default' do
 
   it 'Configure replication in /etc/my.cnf.d/30-replication.cnf' do
     expect(chef_run).to create_template('/etc/my.cnf.d/30-replication.cnf')
-    expect(chef_run).to render_file('/etc/my.cnf.d/replication.cnf')
+    expect(chef_run).to render_file('/etc/my.cnf.d/30-replication.cnf')
   end
 
   it 'Configure InnoDB with attributes' do
-    expect(chef_run).to add_mariadb_configuration('innodb')
+    expect(chef_run).to add_mariadb_configuration('20-innodb')
     expect(chef_run).to render_file('/etc/my.cnf.d/20-innodb.cnf')
       .with_content(/innodb_buffer_pool_size = 256M/)
     expect(chef_run).to create_template('/etc/my.cnf.d/20-innodb.cnf')

--- a/spec/debian_galera10_spec.rb
+++ b/spec/debian_galera10_spec.rb
@@ -71,7 +71,7 @@ describe 'debian::mariadb::galera10-rsync' do
   end
 
   it 'Create Galera conf file' do
-    expect(chef_run).to add_mariadb_configuration('galera')
+    expect(chef_run).to add_mariadb_configuration('90-galera')
     expect(chef_run).to create_template('/etc/mysql/conf.d/90-galera.cnf')
       .with(
         user:  'root',

--- a/spec/debian_galera10_spec.rb
+++ b/spec/debian_galera10_spec.rb
@@ -50,12 +50,12 @@ describe 'debian::mariadb::galera10-rsync' do
   end
 
   it 'Configure InnoDB' do
-    expect(chef_run).to render_file('/etc/mysql/conf.d/innodb.cnf')
+    expect(chef_run).to render_file('/etc/mysql/conf.d/20-innodb.cnf')
       .with_content(/innodb_buffer_pool_size = 256M/)
   end
 
   it 'Configure Replication' do
-    expect(chef_run).to render_file('/etc/mysql/conf.d/replication.cnf')
+    expect(chef_run).to render_file('/etc/mysql/conf.d/30-replication.cnf')
       .with_content(%r{^log_bin = /var/log/mysql/mariadb-bin$})
   end
 
@@ -72,13 +72,13 @@ describe 'debian::mariadb::galera10-rsync' do
 
   it 'Create Galera conf file' do
     expect(chef_run).to add_mariadb_configuration('galera')
-    expect(chef_run).to create_template('/etc/mysql/conf.d/galera.cnf')
+    expect(chef_run).to create_template('/etc/mysql/conf.d/90-galera.cnf')
       .with(
         user:  'root',
         group: 'mysql',
         mode:  '0640'
       )
-    expect(chef_run).to render_file('/etc/mysql/conf.d/galera.cnf')
+    expect(chef_run).to render_file('/etc/mysql/conf.d/90-galera.cnf')
       .with_content(%r{^wsrep_cluster_address = gcomm://galera1.domain,galera2.domain$})
   end
 
@@ -148,5 +148,9 @@ describe 'debian::mariadb::galera10-xtrabackup-v2' do
 
   it 'Install Socat package' do
     expect(chef_run).to install_package('socat')
+  end
+
+  it 'Install pv package' do
+    expect(chef_run).to install_package('pv')
   end
 end

--- a/spec/debian_galera55_spec.rb
+++ b/spec/debian_galera55_spec.rb
@@ -42,7 +42,7 @@ describe 'debian::mariadb::galera55' do
   end
 
   it 'Create Galera conf file' do
-    expect(chef_run).to add_mariadb_configuration('galera')
+    expect(chef_run).to add_mariadb_configuration('90-galera')
     expect(chef_run).to create_template('/etc/mysql/conf.d/90-galera.cnf')
       .with(
         user:  'root',

--- a/spec/debian_galera55_spec.rb
+++ b/spec/debian_galera55_spec.rb
@@ -32,18 +32,18 @@ describe 'debian::mariadb::galera55' do
   end
 
   it 'Configure InnoDB' do
-    expect(chef_run).to render_file('/etc/mysql/conf.d/innodb.cnf')
+    expect(chef_run).to render_file('/etc/mysql/conf.d/20-innodb.cnf')
       .with_content(/innodb_buffer_pool_size = 256M/)
   end
 
   it 'Configure Replication' do
-    expect(chef_run).to render_file('/etc/mysql/conf.d/replication.cnf')
+    expect(chef_run).to render_file('/etc/mysql/conf.d/30-replication.cnf')
       .with_content(%r{^log_bin = /var/log/mysql/mariadb-bin$})
   end
 
   it 'Create Galera conf file' do
     expect(chef_run).to add_mariadb_configuration('galera')
-    expect(chef_run).to create_template('/etc/mysql/conf.d/galera.cnf')
+    expect(chef_run).to create_template('/etc/mysql/conf.d/90-galera.cnf')
       .with(
         user:  'root',
         group: 'mysql',

--- a/spec/debian_spec.rb
+++ b/spec/debian_spec.rb
@@ -37,9 +37,9 @@ describe 'debian::mariadb::default' do
 
   it 'Configure InnoDB with attributes' do
     expect(chef_run).to add_mariadb_configuration('innodb')
-    expect(chef_run).to render_file('/etc/mysql/conf.d/innodb.cnf')
+    expect(chef_run).to render_file('/etc/mysql/conf.d/20-innodb.cnf')
       .with_content(/innodb_buffer_pool_size = 256M/)
-    expect(chef_run).to create_template('/etc/mysql/conf.d/innodb.cnf')
+    expect(chef_run).to create_template('/etc/mysql/conf.d/20-innodb.cnf')
       .with(
         user:  'root',
         group: 'mysql',
@@ -49,7 +49,7 @@ describe 'debian::mariadb::default' do
 
   it 'Configure Replication' do
     expect(chef_run).to add_mariadb_configuration('replication')
-    expect(chef_run).to create_template('/etc/mysql/conf.d/replication.cnf')
+    expect(chef_run).to create_template('/etc/mysql/conf.d/30-replication.cnf')
   end
 
   it 'Configure Preseeding' do

--- a/spec/debian_spec.rb
+++ b/spec/debian_spec.rb
@@ -36,7 +36,7 @@ describe 'debian::mariadb::default' do
   end
 
   it 'Configure InnoDB with attributes' do
-    expect(chef_run).to add_mariadb_configuration('innodb')
+    expect(chef_run).to add_mariadb_configuration('20-innodb')
     expect(chef_run).to render_file('/etc/mysql/conf.d/20-innodb.cnf')
       .with_content(/innodb_buffer_pool_size = 256M/)
     expect(chef_run).to create_template('/etc/mysql/conf.d/20-innodb.cnf')
@@ -48,7 +48,7 @@ describe 'debian::mariadb::default' do
   end
 
   it 'Configure Replication' do
-    expect(chef_run).to add_mariadb_configuration('replication')
+    expect(chef_run).to add_mariadb_configuration('30-replication')
     expect(chef_run).to create_template('/etc/mysql/conf.d/30-replication.cnf')
   end
 

--- a/templates/default/mariadb-server.seed.erb
+++ b/templates/default/mariadb-server.seed.erb
@@ -5,7 +5,7 @@ pack_w_version = @package_name + '-' + node['mariadb']['install']['version']
 <%= pack_w_version %>	mysql-server/root_password_again	select	<%= node['mariadb']['server_root_password'] %>
 <%= pack_w_version %>	mysql-server/root_password	select	<%= node['mariadb']['server_root_password'] %>
 <%= pack_w_version %>	mysql-server/error_setting_password	boolean	false
-<%= pack_w_version %>	mysql-server-5.1/nis_warning	note	
+<%= pack_w_version %>	mysql-server-5.1/nis_warning	note
 <%= pack_w_version %>	mysql-server-5.1/start_on_boot	boolean	true
 <%= pack_w_version %>	<%= pack_w_version %>/really_downgrade	boolean	false
 <%= pack_w_version %>	mysql-server-5.1/postrm_remove_databases	boolean	false

--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -166,7 +166,12 @@ default_storage_engine	= <%= node['mariadb']['mysqld']['default_storage_engine']
 <%   node['mariadb']['plugins_loading'].each { |plugin, loading| -%>
   <% plugin_load.push(loading) if node['mariadb']['plugins'][plugin] %>
 <%   } -%>
+<% unless plugin_load.empty? -%>
+#
+# * Plugins Options
+#
 plugin-load = <%= plugin_load.join(';') %>
+<% end -%>
 
 [mysqldump]
 <% if node['mariadb']['mysqldump']['quick'].empty? -%>

--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -188,4 +188,3 @@ key_buffer		= <%= node['mariadb']['isamchk']['key_buffer'] %>
 #   The files must end with '.cnf', otherwise they'll be ignored.
 #
 !includedir <%= node['mariadb']['configuration']['includedir'] %>/
-

--- a/templates/default/root.cnf.erb
+++ b/templates/default/root.cnf.erb
@@ -1,0 +1,5 @@
+<% %w{mysql mysqldump mysqlcheck mysqladmin mysqlshow}.each do |section| -%>
+[<%= section %>]
+user=root
+password=<%= node['mariadb']['server_root_password'] %>
+<% end -%>

--- a/test/integration/default/serverspec/mariadb_spec.rb
+++ b/test/integration/default/serverspec/mariadb_spec.rb
@@ -33,7 +33,7 @@ describe "verify the tuning attributes set in #{mysql_config_file}" do
     myisam_sort_buffer_size: '512M'
   }.each do |attribute, value|
     describe command("grep -E \"^#{attribute}\\s+\" #{mysql_config_file}") do
-      its(:stdout)  { should match(/#{value}/) }
+      its(:stdout) { should match(/#{value}/) }
     end
   end
 end

--- a/test/integration/native/serverspec/mariadb_spec.rb
+++ b/test/integration/native/serverspec/mariadb_spec.rb
@@ -36,7 +36,7 @@ describe "verify the tuning attributes set in #{mysql_config_file}" do
     myisam_sort_buffer_size: '512M'
   }.each do |attribute, value|
     describe command("grep -E \"^#{attribute}\\s+\" #{mysql_config_file}") do
-      its(:stdout)  { should match(/#{value}/) }
+      its(:stdout) { should match(/#{value}/) }
     end
   end
 end

--- a/test/integration/plugins/serverspec/mariadb_spec.rb
+++ b/test/integration/plugins/serverspec/mariadb_spec.rb
@@ -13,5 +13,5 @@ describe command('/usr/bin/mysql -u root -B -N -e "SELECT 1 '\
                   'FROM information_schema.plugins '\
                   'WHERE PLUGIN_NAME = \"SERVER_AUDIT\"'\
                   'AND PLUGIN_STATUS = \"ACTIVE\""') do
-  its(:stdout)  { should match(/^1$/) }
+  its(:stdout) { should match(/^1$/) }
 end


### PR DESCRIPTION
Dear sinfomicien

thank you for your great work! As we need to deploy a MariaDB 10.1 Galera Cluster I added support for it and enabled data_bag support to use encrypted passwords with the following database user:

root
debian-sys-maint
sstuser

while 'sstuser' is used by xtrabackup.

All the best,
Flo
