### PR TITLE
Move /root/my.cnf sections to attributes

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -15,6 +15,14 @@ else
   default['mariadb']['mysqld_safe']['socket'] = '/var/run/mysqld/mysqld.sock'
 end
 
+default['mariadb']['sections'] = %w(
+  client
+  mysql
+  mysqldump
+  mysqlcheck
+  mysqladmin
+  mysqlshow)
+
 #
 # mysqld default configuration
 #

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description 'Installs/Configures MariaDB'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/sinfomicien/mariadb'
 issues_url 'https://github.com/sinfomicien/mariadb/issues'
-version '0.3.1'
+version '0.3.2'
 
 supports 'ubuntu'
 supports 'debian', '>= 7.0'

--- a/templates/default/root.cnf.erb
+++ b/templates/default/root.cnf.erb
@@ -1,4 +1,4 @@
-<% %w{mysql mysqldump mysqlcheck mysqladmin mysqlshow}.each do |section| -%>
+<% node['mariadb']['sections'].each do |section| -%>
 [<%= section %>]
 user=root
 password=<%= node['mariadb']['server_root_password'] %>


### PR DESCRIPTION
Move /root/my.cnf sections to attributes. This is needed, because some clients rely on [client] section and would be great to have it dynamically overridden.
