### PR TITLE
make databags optional

### DIFF
--- a/recipes/galera.rb
+++ b/recipes/galera.rb
@@ -20,22 +20,28 @@
 if Chef::Config[:solo]
   Chef::Log.warn('This recipe uses search. Chef Solo does not support search.')
 else
-  exist_data_bag_mariadb_root = search(:mariadb, 'id:user_root').first
-  unless exist_data_bag_mariadb_root.nil?
-    data_bag_mariadb_root = data_bag_item('mariadb', 'user_root')
-    node.override['mariadb']['server_root_password'] = data_bag_mariadb_root['password']
+  if node['mariadb']['server_root_password'].nil?
+    exist_data_bag_mariadb_root = search(:mariadb, 'id:user_root').first
+    unless exist_data_bag_mariadb_root.nil?
+      data_bag_mariadb_root = data_bag_item('mariadb', 'user_root')
+      node.override['mariadb']['server_root_password'] = data_bag_mariadb_root['password']
+    end
   end
 
-  exist_data_bag_mariadb_debian = search(:mariadb, 'id:user_debian').first
-  unless exist_data_bag_mariadb_debian.nil?
-    data_bag_mariadb_debian = data_bag_item('mariadb', 'user_debian')
-    node.override['mariadb']['debian']['password'] = data_bag_mariadb_debian['password']
+  if node['mariadb']['debian']['password'].nil?
+    exist_data_bag_mariadb_debian = search(:mariadb, 'id:user_debian').first
+    unless exist_data_bag_mariadb_debian.nil?
+      data_bag_mariadb_debian = data_bag_item('mariadb', 'user_debian')
+      node.override['mariadb']['debian']['password'] = data_bag_mariadb_debian['password']
+    end
   end
 
-  exist_data_bag_mariadb_sstuser = search(:mariadb, 'id:user_sstuser').first
-  unless exist_data_bag_mariadb_sstuser.nil?
-    data_bag_mariadb_sstuser = data_bag_item('mariadb', 'user_sstuser')
-    node.override['mariadb']['galera']['wsrep_sst_auth'] = data_bag_mariadb_sstuser['user_password']
+  if node['mariadb']['galera']['wsrep_sst_auth'].nil?
+    exist_data_bag_mariadb_sstuser = search(:mariadb, 'id:user_sstuser').first
+    unless exist_data_bag_mariadb_sstuser.nil?
+      data_bag_mariadb_sstuser = data_bag_item('mariadb', 'user_sstuser')
+      node.override['mariadb']['galera']['wsrep_sst_auth'] = data_bag_mariadb_sstuser['user_password']
+    end
   end
 end
 


### PR DESCRIPTION
Just as the title says - I have a lot of complexity in my wrapper cookbook, which includes pulling from Chef Vault for instance. Because of this, I'd like to be able to provide attributes myself without having to clutter up my env with a ton of databag items.

Thanks!
