### PR TITLE
fix redhat package name for 10.1 ver

### DIFF
--- a/recipes/_redhat_galera.rb
+++ b/recipes/_redhat_galera.rb
@@ -22,7 +22,13 @@ package 'MariaDB-shared' do
   action :install
 end
 
-package 'MariaDB-Galera-server' do
+package_name = if node['mariadb']['install']['version'].to_f < 10.1
+                 'MariaDB-Galera-server'
+               else
+                 'MariaDB-server'
+               end
+
+package package_name do
   action :install
   notifies :create, 'directory[/var/log/mysql]', :immediately
   notifies :start, 'service[mysql]', :immediately


### PR DESCRIPTION
Galera Cluster is included in the default MariaDB packages from 10.1. More info:
https://mariadb.com/kb/en/mariadb/yum/#installing-mariadb-galera-cluster-with-yum
