### PR TITLE
Allow gcomm address override in galera recipe

### DIFF
--- a/recipes/galera.rb
+++ b/recipes/galera.rb
@@ -74,38 +74,41 @@ end
 
 include_recipe "#{cookbook_name}::config"
 
-galera_cluster_nodes = []
-if !node['mariadb'].attribute?('rspec') && Chef::Config[:solo] || Chef::Config[:local_mode]
-  if node['mariadb']['galera']['cluster_nodes'].empty?
-    Chef::Log.warn('By default this recipe uses search (unsupported by Chef Solo).' \
-                   ' Nodes may manually be configured as attributes.')
+first = true
+if node['mariadb']['galera']['gcomm_address'].nil?
+  galera_cluster_nodes = []
+  if !node['mariadb'].attribute?('rspec') && Chef::Config[:solo] || Chef::Config[:local_mode]
+    if node['mariadb']['galera']['cluster_nodes'].empty?
+      Chef::Log.warn('By default this recipe uses search (unsupported by Chef Solo).' \
+                     ' Nodes may manually be configured as attributes.')
+    else
+      galera_cluster_nodes = node['mariadb']['galera']['cluster_nodes']
+    end
   else
-    galera_cluster_nodes = node['mariadb']['galera']['cluster_nodes']
+    if node['mariadb']['galera']['cluster_search_query'].empty?
+      galera_cluster_nodes = search(
+        :node, \
+        "mariadb_galera_cluster_name:#{node['mariadb']['galera']['cluster_name']}"
+      )
+    else
+      galera_cluster_nodes = search 'node', node['mariadb']['galera']['cluster_search_query']
+      log 'Chef search results' do
+        message "Searching for \"#{node['mariadb']['galera']['cluster_search_query']}\" \
+          resulted in \"#{galera_cluster_nodes}\" ..."
+      end
+    end
+    # Sort Nodes by fqdn
+    galera_cluster_nodes.sort! { |x, y| x[:fqdn] <=> y[:fqdn] }
+  end
+  gcomm = 'gcomm://'
+  galera_cluster_nodes.each do |lnode|
+    next unless lnode.name != node.name
+    gcomm += ',' unless first
+    gcomm += lnode['fqdn']
+    first = false
   end
 else
-  if node['mariadb']['galera']['cluster_search_query'].empty?
-    galera_cluster_nodes = search(
-      :node, \
-      "mariadb_galera_cluster_name:#{node['mariadb']['galera']['cluster_name']}"
-    )
-  else
-    galera_cluster_nodes = search 'node', node['mariadb']['galera']['cluster_search_query']
-    log 'Chef search results' do
-      message "Searching for \"#{node['mariadb']['galera']['cluster_search_query']}\" \
-        resulted in \"#{galera_cluster_nodes}\" ..."
-    end
-  end
-  # Sort Nodes by fqdn
-  galera_cluster_nodes.sort! { |x, y| x[:fqdn] <=> y[:fqdn] }
-end
-
-first = true
-gcomm = 'gcomm://'
-galera_cluster_nodes.each do |lnode|
-  next unless lnode.name != node.name
-  gcomm += ',' unless first
-  gcomm += lnode['fqdn']
-  first = false
+  gcomm = node['mariadb']['galera']['gcomm_address']
 end
 
 galera_options = {}


### PR DESCRIPTION
Hello!

  I have a situation where I really would like to use the Galera packages (for testing purposes), but would not like to / cannot use Chef Search. This patch allows me to manually define a `gcomm://` address for Galera replication.

  This allows a no-search stand-alone galera by setting:

`node.override['mariadb']['galera']['gcomm_address'] = 'gcomm://'`

Thanks!
