### PR TITLE
improve general and slow log configuration

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -66,7 +66,16 @@ default['mariadb']['mysqld']['query_cache_size'] = '64M'
 default['mariadb']['mysqld']['query_cache_type'] = ''
 default['mariadb']['mysqld']['default_storage_engine'] = 'InnoDB'
 default['mariadb']['mysqld']['options'] = {}
-
+# logging
+default['mariadb']['mysqld']['general_log_file'] = '/var/log/mysql/mysql.log'
+default['mariadb']['mysqld']['general_log'] = 0
+default['mariadb']['mysqld']['log_warnings'] = 2
+default['mariadb']['mysqld']['slow_query_log'] = 0
+default['mariadb']['mysqld']['slow_query_log_file'] = '/var/log/mysql/mariadb-slow.log'
+default['mariadb']['mysqld']['long_query_time'] = 10
+default['mariadb']['mysqld']['log_slow_rate_limit'] = 1000
+default['mariadb']['mysqld']['log_slow_verbosity'] = 'query_plan'
+default['mariadb']['mysqld']['log_output'] = 'FILE'
 #
 # InnoDB default configuration
 #

--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -105,20 +105,23 @@ query_cache_type                = <%= node['mariadb']['mysqld']['query_cache_typ
 # Both location gets rotated by the cronjob.
 # Be aware that this log type is a performance killer.
 # As of 5.1 you can enable the log at runtime!
-#general_log_file        = /var/log/mysql/mysql.log
-#general_log             = 1
+general_log_file        = <%= node['mariadb']['mysqld']['general_log_file'] %>
+general_log             = <%= node['mariadb']['mysqld']['general_log'] %>
 #
 # Error logging goes to syslog due to /etc/mysql/conf.d/mysqld_safe_syslog.cnf.
 #
 # we do want to know about network errors and such
-log_warnings		= 2
+log_warnings		= <%= node['mariadb']['mysqld']['log_warnings'] %>
 #
 # Enable the slow query log to see queries with especially long duration
 #slow_query_log[={0|1}]
-slow_query_log_file	= /var/log/mysql/mariadb-slow.log
-long_query_time = 10
-#log_slow_rate_limit	= 1000
-log_slow_verbosity	= query_plan
+slow_query_log = <%= node['mariadb']['mysqld']['slow_query_log'] %>
+slow_query_log_file	= <%= node['mariadb']['mysqld']['slow_query_log_file'] %>
+long_query_time = <%= node['mariadb']['mysqld']['long_query_time'] %>
+log_slow_rate_limit	= <%= node['mariadb']['mysqld']['log_slow_rate_limit'] %>
+log_slow_verbosity	= <%= node['mariadb']['mysqld']['log_slow_verbosity'] %>
+# Logging output type
+log_output = <%= node['mariadb']['mysqld']['log_output'] %>
 
 #log-queries-not-using-indexes
 #log_slow_admin_statements


### PR DESCRIPTION
Title pretty much speaks for itself. General and slow logging options were not attributes and therefore could not be configured.
