### PR TITLE
fix travis rack build errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.1.7
+- 2.2.2
 bundler_args: --without development
 gemfile:
 - Gemfile


### PR DESCRIPTION
ruby >= 2.2.2 needed for rack, travis throwing build errors, i.e. https://travis-ci.org/sinfomicien/mariadb/builds/160927735
