### PR TITLE
Add support for managing the debian-sys-maint user in plain MariaDB

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -145,6 +145,7 @@ default['mariadb']['client']['development_files'] = true
 #
 # debian specific configuration
 #
+default['mariadb']['debian']['manage_maint_user'] = false
 default['mariadb']['debian']['user'] = 'debian-sys-maint'
 default['mariadb']['debian']['password'] = 'please-change-me'
 default['mariadb']['debian']['host'] = 'localhost'

--- a/recipes/_debian_user.rb
+++ b/recipes/_debian_user.rb
@@ -1,0 +1,61 @@
+#
+# Cookbook Name:: mariadb
+# Recipe:: _debian_user
+#
+# Copyright 2014, blablacar.com
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Configure the debian-sys-maint user
+template '/etc/mysql/debian.cnf' do
+  sensitive true
+  source 'debian.cnf.erb'
+  owner 'root'
+  group 'root'
+  mode '0600'
+end
+
+grants_command = 'mysql -r -B -N -u root '
+
+if node['mariadb']['server_root_password'].is_a?(String)
+  grants_command += '--password=\'' + \
+    node['mariadb']['server_root_password'] + '\' '
+end
+
+grants_command += '-e "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, ' \
+  'DROP, RELOAD, SHUTDOWN, PROCESS, FILE, REFERENCES, ' \
+  'INDEX, ALTER, SHOW DATABASES, SUPER, CREATE TEMPORARY ' \
+  'TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, ' \
+  'REPLICATION CLIENT, CREATE VIEW, SHOW VIEW, CREATE ' \
+  'ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER ON ' \
+  ' *.* TO \'' + node['mariadb']['debian']['user'] + \
+  '\'@\'' + node['mariadb']['debian']['host'] + '\' ' \
+  'IDENTIFIED BY \'' + \
+  node['mariadb']['debian']['password'] + '\' WITH GRANT ' \
+  'OPTION"'
+
+execute 'correct-debian-grants' do
+  command grants_command
+  action :run
+  only_if do
+    cmd = Mixlib::ShellOut.new('/usr/bin/mysql --user="' + \
+      node['mariadb']['debian']['user'] + \
+      '" --password="' + node['mariadb']['debian']['password'] + \
+      '" -r -B -N -e "SELECT 1"')
+    cmd.run_command
+    cmd.error?
+  end
+  ignore_failure true
+  sensitive true
+end

--- a/recipes/galera.rb
+++ b/recipes/galera.rb
@@ -17,6 +17,12 @@
 # limitations under the License.
 #
 
+if platform?('debian', 'ubuntu') && !node['mariadb']['debian']['manage_maint_user']
+  Chef::Log.warn('The galera recipe ignores the mariadb.debian.manage_maint_user attribute '\
+    "b/c it must manage the #{node['mariadb']['debian']['user']} user. Please set the "\
+    'mariadb.debian.manage_maint_user attribute to true to make this warning go away.')
+end
+
 if Chef::Config[:solo]
   Chef::Log.warn('This recipe uses search. Chef Solo does not support search.')
 else
@@ -186,49 +192,7 @@ end
 # Under debian system we have to change the debian-sys-maint default password.
 # This password is the same for the overall cluster.
 #
-if platform?('debian', 'ubuntu')
-  template '/etc/mysql/debian.cnf' do
-    sensitive true
-    source 'debian.cnf.erb'
-    owner 'root'
-    group 'root'
-    mode '0600'
-  end
-
-  grants_command = 'mysql -r -B -N -u root '
-
-  if node['mariadb']['server_root_password'].is_a?(String)
-    grants_command += '--password=\'' + \
-      node['mariadb']['server_root_password'] + '\' '
-  end
-
-  grants_command += '-e "GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, ' \
-    'DROP, RELOAD, SHUTDOWN, PROCESS, FILE, REFERENCES, ' \
-    'INDEX, ALTER, SHOW DATABASES, SUPER, CREATE TEMPORARY ' \
-    'TABLES, LOCK TABLES, EXECUTE, REPLICATION SLAVE, ' \
-    'REPLICATION CLIENT, CREATE VIEW, SHOW VIEW, CREATE ' \
-    'ROUTINE, ALTER ROUTINE, CREATE USER, EVENT, TRIGGER ON ' \
-    ' *.* TO \'' + node['mariadb']['debian']['user'] + \
-    '\'@\'' + node['mariadb']['debian']['host'] + '\' ' \
-    'IDENTIFIED BY \'' + \
-    node['mariadb']['debian']['password'] + '\' WITH GRANT ' \
-    'OPTION"'
-
-  execute 'correct-debian-grants' do
-    command grants_command
-    action :run
-    only_if do
-      cmd = Mixlib::ShellOut.new('/usr/bin/mysql --user="' + \
-        node['mariadb']['debian']['user'] + \
-        '" --password="' + node['mariadb']['debian']['password'] + \
-        '" -r -B -N -e "SELECT 1"')
-      cmd.run_command
-      cmd.error?
-    end
-    ignore_failure true
-    sensitive true
-  end
-end
+include_recipe 'mariadb::_debian_user' if platform?('debian', 'ubuntu')
 
 #
 # Galera SST method xtrabackup will need a seperated mysql sstuser as root

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -128,6 +128,9 @@ if  node['mariadb']['allow_root_pass_change'] ||
   end
 end
 
+# Change debian-sys-maint password if desired
+include_recipe "#{cookbook_name}::_debian_user" if node['mariadb']['debian']['manage_maint_user']
+
 # MariaDB Plugins
 include_recipe "#{cookbook_name}::plugins" if \
   node['mariadb']['plugins_options']['auto_install']


### PR DESCRIPTION
Note the warning in the galera recipe. I wasn't sure of a better way to handle this. Open to better ideas.
