### PR TITLE
open_files_limit should typically be a fixnum, not a string, so empty is not correct - swap to nil?

### DIFF
--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -74,9 +74,7 @@ max_heap_table_size	= <%= node['mariadb']['mysqld']['max_heap_table_size']     %
 # the first time they are touched. On error, make copy and try a repair.
 myisam_recover          = <%= node['mariadb']['mysqld']['myisam_recover']  %>
 key_buffer_size		= <%= node['mariadb']['mysqld']['key_buffer_size'] %>
-<% if node['mariadb']['mysqld']['open_files_limit'].empty? -%>
-#open-files-limit	= 2000
-<% else -%>
+<% unless node['mariadb']['mysqld']['open_files_limit'].nil? -%>
 open-files-limit	= <%= node['mariadb']['mysqld']['open_files_limit'] %>
 <% end -%>
 table_open_cache	= <%= node['mariadb']['mysqld']['table_open_cache']        %>


### PR DESCRIPTION
re-attempting #97 