### PR TITLE
Update Kitchen tests

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -1,0 +1,154 @@
+---
+driver:
+  name: dokken
+  privileged: true # because Docker and SystemD/Upstart
+  chef_version: current
+
+transport:
+  name: dokken
+
+provisioner:
+  name: dokken
+
+platforms:
+- name: centos-6
+  driver:
+    image: centos:6
+    platform: rhel
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN yum -y install which initscripts
+
+- name: centos-7
+  driver:
+    image: centos:7
+    platform: rhel
+    pid_one_command: /usr/lib/systemd/systemd
+    intermediate_instructions:
+      - RUN yum -y install lsof which initscripts net-tools
+
+- name: debian-7
+  driver:
+    image: debian:7
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install lsb-release net-tools -y
+
+- name: debian-8
+  driver:
+    image: debian:8
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install lsb-release net-tools -y
+
+- name: ubuntu-12.04
+  driver:
+    image: ubuntu-upstart:12.04
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install net-tools -y
+
+- name: ubuntu-14.04
+  driver:
+    image: ubuntu-upstart:14.04
+    pid_one_command: /sbin/init
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install net-tools -y
+
+- name: ubuntu-16.04
+  driver:
+    image: ubuntu:16.04
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install net-tools -y
+
+suites:
+  #
+  # default
+  #
+  - name: default
+    run_list:
+      - recipe[mariadb::default]
+    attributes:
+      mariadb:
+        use_default_repository: true
+  #
+  # native
+  #
+  - name: native
+    run_list:
+      - recipe[mariadb::default]
+    attributes:
+      mariadb:
+        install:
+          prefer_os_package: true
+    includes:
+      - centos-7
+  #
+  # replication
+  #
+  - name: replication
+    run_list:
+      - recipe[mariadb_test::replication]
+    attributes:
+      mariadb:
+        use_default_repository: true
+  #
+  # galera
+  #
+  - name: galera
+    run_list:
+      - recipe[mariadb::galera]
+    attributes:
+      mariadb:
+        use_default_repository: true
+  #
+  # datadir_changed
+  #
+  - name: datadir_changed
+    run_list:
+      - recipe[mariadb::default]
+    attributes:
+      mariadb:
+        use_default_repository: true
+        mysqld:
+          datadir: /home/mysql
+  #
+  # port_changed
+  #
+  - name: port_changed
+    run_list:
+      - recipe[mariadb::default]
+    attributes:
+      mariadb:
+        server_root_password: gsql
+        use_default_repository: true
+        mysqld:
+          port: 3307
+  #
+  # plugins
+  #
+  - name: plugins
+    run_list:
+      - recipe[mariadb::default]
+    attributes:
+      mariadb:
+        use_default_repository: true
+        plugins:
+          audit: true
+  #
+  # no_binlog
+  #
+  - name: no_binlog
+    run_list:
+      - recipe[mariadb::default]
+    attributes:
+      mariadb:
+        use_default_repository: true
+        replication:
+          log_bin: false

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -5,21 +5,31 @@ driver:
 provisioner:
   name: chef_zero
 
+verifier:
+  name: inspec
+
 platforms:
-  - name: debian-7.11
-  - name: ubuntu-12.04
   - name: centos-6.8
-  - name: centos-7.2
+  - name: centos-7.3
+  - name: debian-7.11
+  - name: debian-8.7
+  - name: ubuntu-12.04
   - name: ubuntu-14.04
-  - name: fedora-25
+  - name: ubuntu-16.04
 
 suites:
+  #
+  # default
+  #
   - name: default
     run_list:
       - recipe[mariadb::default]
     attributes:
       mariadb:
         use_default_repository: true
+  #
+  # native
+  #
   - name: native
     run_list:
       - recipe[mariadb::default]
@@ -28,20 +38,28 @@ suites:
         install:
           prefer_os_package: true
     includes:
-      - centos-7.0
-      - fedora-21
+      - centos-7.3
+  #
+  # replication
+  #
   - name: replication
     run_list:
       - recipe[mariadb_test::replication]
     attributes:
       mariadb:
         use_default_repository: true
+  #
+  # galera
+  #
   - name: galera
     run_list:
       - recipe[mariadb::galera]
     attributes:
       mariadb:
         use_default_repository: true
+  #
+  # datadir_changed
+  #
   - name: datadir_changed
     run_list:
       - recipe[mariadb::default]
@@ -50,6 +68,9 @@ suites:
         use_default_repository: true
         mysqld:
           datadir: /home/mysql
+  #
+  # port_changed
+  #
   - name: port_changed
     run_list:
       - recipe[mariadb::default]
@@ -59,6 +80,9 @@ suites:
         use_default_repository: true
         mysqld:
           port: 3307
+  #
+  # plugins
+  #
   - name: plugins
     run_list:
       - recipe[mariadb::default]
@@ -67,7 +91,10 @@ suites:
         use_default_repository: true
         plugins:
           audit: true
-  - name: no_binlog 
+  #
+  # no_binlog
+  #
+  - name: no_binlog
     run_list:
       - recipe[mariadb::default]
     attributes:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: required
 dist: trusty
 
-# install the stable release of chef-dk.
 addons:
   apt:
     sources:
@@ -9,13 +8,75 @@ addons:
     packages:
       - chefdk
 
+# Don't `bundle install` which takes about 1.5 mins
+install: echo "skip bundle install"
+
+services: docker
+
+env:
+  matrix:
+  - INSTANCE=default-centos-6
+  - INSTANCE=default-centos-7
+  - INSTANCE=default-debian-7
+  - INSTANCE=default-debian-8
+  - INSTANCE=default-ubuntu-1204
+  - INSTANCE=default-ubuntu-1404
+  - INSTANCE=default-ubuntu-1604
+  - INSTANCE=native-centos-7
+  - INSTANCE=replication-centos-6
+  - INSTANCE=replication-centos-7
+  - INSTANCE=replication-debian-7
+  - INSTANCE=replication-debian-8
+  - INSTANCE=replication-ubuntu-1204
+  - INSTANCE=replication-ubuntu-1404
+  - INSTANCE=replication-ubuntu-1604
+  - INSTANCE=galera-centos-6
+  - INSTANCE=galera-centos-7
+  - INSTANCE=galera-debian-7
+  - INSTANCE=galera-debian-8
+  - INSTANCE=galera-ubuntu-1204
+  - INSTANCE=galera-ubuntu-1404
+  - INSTANCE=galera-ubuntu-1604
+  - INSTANCE=datadir-changed-centos-6
+  - INSTANCE=datadir-changed-centos-7
+  - INSTANCE=datadir-changed-debian-7
+  - INSTANCE=datadir-changed-debian-8
+  - INSTANCE=datadir-changed-ubuntu-1204
+  - INSTANCE=datadir-changed-ubuntu-1404
+  - INSTANCE=datadir-changed-ubuntu-1604
+  - INSTANCE=port-changed-centos-6
+  - INSTANCE=port-changed-centos-7
+  - INSTANCE=port-changed-debian-7
+  - INSTANCE=port-changed-debian-8
+  - INSTANCE=port-changed-ubuntu-1204
+  - INSTANCE=port-changed-ubuntu-1404
+  - INSTANCE=port-changed-ubuntu-1604
+  - INSTANCE=plugins-centos-6
+  - INSTANCE=plugins-centos-7
+  - INSTANCE=plugins-debian-7
+  - INSTANCE=plugins-debian-8
+  - INSTANCE=plugins-ubuntu-1204
+  - INSTANCE=plugins-ubuntu-1404
+  - INSTANCE=plugins-ubuntu-1604
+  - INSTANCE=no-binlog-centos-6
+  - INSTANCE=no-binlog-centos-7
+  - INSTANCE=no-binlog-debian-7
+  - INSTANCE=no-binlog-debian-8
+  - INSTANCE=no-binlog-ubuntu-1204
+  - INSTANCE=no-binlog-ubuntu-1404
+  - INSTANCE=no-binlog-ubuntu-1604
+
+before_script:
+  - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
+  - eval "$(/opt/chefdk/bin/chef shell-init bash)" && chef gem install berkshelf
+  - /opt/chefdk/embedded/bin/chef --version
+  - /opt/chefdk/embedded/bin/cookstyle --version
+  - /opt/chefdk/embedded/bin/foodcritic --version
+
+script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml /opt/chefdk/embedded/bin/kitchen verify ${INSTANCE}
+
 matrix:
   include:
-    - before_script:
-      - eval "$(/opt/chefdk/bin/chef shell-init bash)"
-      - /opt/chefdk/embedded/bin/chef --version
-      - /opt/chefdk/embedded/bin/cookstyle --version
-      - /opt/chefdk/embedded/bin/foodcritic --version
     - script:
       - /opt/chefdk/bin/chef exec rake
       env: UNIT_AND_LINT=1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,19 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Make open-files-limit configurable (previously commented out in template) (#97)
 
+### Added
+
+- Add Docker tests to Travis for smoke tests
+- Add docker CI tests (add new APT key to fix #107, add Supermarket version badge and change Travis badge to show master build status to README)
+
 ### Changed
 
-- Changed CHANGELOG format to follow [Keep a Changelog (v0.3.0)](http://keepachangelog.com/en/0.3.0/)
+- Change CHANGELOG format to follow [Keep a Changelog (v0.3.0)](http://keepachangelog.com/en/0.3.0/)
+- Update Vagrant box names to match latest OS versions for testing with VirtualBox
+
+### Removed
+
+- Remove Fedora platfrom from Test-Kitchen, not something we'll test on going forward.
 
 ## 1.0.1
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 MariaDB Cookbook
 ================
 
-[![Build Status](https://travis-ci.org/sinfomicien/mariadb.png)](https://travis-ci.org/sinfomicien/mariadb)
+[![Build Status](https://travis-ci.org/sinfomicien/mariadb.svg?branch=master)](https://travis-ci.org/sinfomicien/mariadb) [![Cookbook Version](https://img.shields.io/cookbook/v/mariadb.svg)](https://supermarket.chef.io/cookbooks/mariadb)
 
 Description
 -----------

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -10,13 +10,16 @@ if node['mariadb']['use_default_repository']
   when 'apt'
     include_recipe 'apt::default'
 
+    apt_key = 'CBCB082A1BB943DB'
+    apt_key = 'F1656F24C74CD1D8' if node['platform'] == 'ubuntu' && node['platform_version'].split('.')[0].to_i >= 16
+
     apt_repository "mariadb-#{node['mariadb']['install']['version']}" do
       uri 'http://' + node['mariadb']['apt_repository']['base_url'] + '/' + \
         node['mariadb']['install']['version'] + '/' + node['platform']
       distribution node['lsb']['codename']
       components ['main']
       keyserver 'keyserver.ubuntu.com'
-      key 'CBCB082A1BB943DB'
+      key apt_key
     end
   when 'yum'
     include_recipe 'yum::default'


### PR DESCRIPTION
- Add new APT signing key (also fixes #107)
- Add Docker tests for Travis
- Add Supermarket version badge to README
- Change VirtualBox box names to use recent versions
- Change Travis badge in README to show master build status
- Remove Fedora tests, not something we'll test going forward