### PR TITLE
Enable logging

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -194,3 +194,4 @@ default['mariadb']['audit_plugin']['server_audit_output_type'] = 'file'
 # Syslog(require server_audit_output_type = syslog)
 default['mariadb']['audit_plugin']['server_audit_syslog_facility'] = 'LOG_USER'
 default['mariadb']['audit_plugin']['server_audit_syslog_priority'] = 'LOG_INFO'
+default['mariadb']['audit_plugin']['server_audit_logging'] ='OFF'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -194,4 +194,4 @@ default['mariadb']['audit_plugin']['server_audit_output_type'] = 'file'
 # Syslog(require server_audit_output_type = syslog)
 default['mariadb']['audit_plugin']['server_audit_syslog_facility'] = 'LOG_USER'
 default['mariadb']['audit_plugin']['server_audit_syslog_priority'] = 'LOG_INFO'
-default['mariadb']['audit_plugin']['server_audit_logging'] ='OFF'
+default['mariadb']['audit_plugin']['server_audit_logging'] = 'OFF'

--- a/recipes/_audit_plugin.rb
+++ b/recipes/_audit_plugin.rb
@@ -28,10 +28,10 @@ execute 'install_mariadb_audit_plugin' do
   sensitive true
   not_if do
     cmd = Mixlib::ShellOut.new("#{mysql_cmd} -u root " \
-                               "--password=" + \
+                               '--password=' + \
                                node['mariadb']['server_root_password'] + \
-                               " -B -N -e \"SELECT 1 " \
-                               "FROM information_schema.plugins " \
+                               ' -B -N -e \"SELECT 1 ' \
+                               'FROM information_schema.plugins ' \
                                "WHERE PLUGIN_NAME = 'SERVER_AUDIT'" \
                                "AND PLUGIN_STATUS = 'ACTIVE';\"")
     cmd.run_command
@@ -48,8 +48,9 @@ execute 'configure_mariadb_audit_plugin' do
     'SET GLOBAL server_audit_syslog_facility=\'' + \
     node['mariadb']['audit_plugin']['server_audit_syslog_facility'] + '\';' \
     'SET GLOBAL server_audit_syslog_priority=\'' + \
-    node['mariadb']['audit_plugin']['server_audit_syslog_priority'] + '\';"' \
-    'SET GLOBAL server_audit_logging=\'ON\';' \
+    node['mariadb']['audit_plugin']['server_audit_syslog_priority'] + '\';' \
+    'SET GLOBAL server_audit_logging=\'' + \
+    node['mariadb']['audit_plugin']['server_audit_logging'] + '\';" ' \
     "| #{mysql_cmd}"
   action :nothing
 end

--- a/recipes/_audit_plugin.rb
+++ b/recipes/_audit_plugin.rb
@@ -30,7 +30,7 @@ execute 'install_mariadb_audit_plugin' do
     cmd = Mixlib::ShellOut.new("#{mysql_cmd} -u root " \
                                '--password=' + \
                                node['mariadb']['server_root_password'] + \
-                               ' -B -N -e \"SELECT 1 ' \
+                               ' -B -N -e "SELECT 1 ' \
                                'FROM information_schema.plugins ' \
                                "WHERE PLUGIN_NAME = 'SERVER_AUDIT'" \
                                "AND PLUGIN_STATUS = 'ACTIVE';\"")

--- a/recipes/_audit_plugin.rb
+++ b/recipes/_audit_plugin.rb
@@ -13,8 +13,8 @@ audit_plugin_options['server_audit_syslog_facility'] = \
   node['mariadb']['audit_plugin']['server_audit_syslog_facility']
 audit_plugin_options['server_audit_syslog_priority'] = \
   node['mariadb']['audit_plugin']['server_audit_syslog_priority']
-
-audit_plugin_options['server_audit_logging'] = 'ON'
+audit_plugin_options['server_audit_logging'] = \
+  node['mariadb']['audit_plugin']['server_audit_logging']
 
 # Install the MariaDB Audit Plugin
 mysql_cmd = mysqlbin_cmd(node['mariadb']['install']['prefer_scl_package'],


### PR DESCRIPTION
This enables logging by default in this recipe, not sure why it wasn't by default, I mean why bother configuring all this logging if you don't want to use it? Also adds the password and user to the mysql commands and marks the execute as sensitive.