### PR TITLE
Prevent removal of MariaDB-compat for centos-7 #2

### DIFF
--- a/recipes/_redhat_client.rb
+++ b/recipes/_redhat_client.rb
@@ -23,5 +23,5 @@ use_os_native = use_os_native_package?(node['mariadb']['install']['prefer_os_pac
 # To force removing of mariadb-libs on CentOS >= 7
 package 'mysql-libs' do
   action :remove
-  not_if { use_os_native }
+  not_if { use_os_native || (node['platform'] == 'centos' && node['platform_version'].to_i >= 7) }
 end

--- a/spec/centos_spec.rb
+++ b/spec/centos_spec.rb
@@ -276,7 +276,78 @@ describe 'centos::mariadb::client' do
     end
   end
 
-  context 'Installation from SCL repository' do
+  context 'Installation from SCL repository (centos 6)' do
+    cached(:chef_run) do
+      runner = ChefSpec::ServerRunner.new(
+        platform: 'centos', version: '6.0',
+        step_into: ['mariadb_configuration']
+      ) do |node|
+        node.automatic['memory']['total'] = '2048kB'
+        node.automatic['ipaddress'] = '1.1.1.1'
+        node.override['mariadb']['install']['prefer_scl_package'] = true
+      end
+      runner.converge('mariadb::client')
+    end
+
+    let(:mariadb_client_package) { chef_run.package('MariaDB-client') }
+    let(:mariadb_devel_package) { chef_run.package('MariaDB-devel') }
+
+    it 'Include SCL repository recipe' do
+      expect(chef_run).to include_recipe('yum-scl::default')
+    end
+
+    it 'Remove mysql-libs package' do
+      expect(chef_run).to remove_package('mysql-libs')
+    end
+
+    context 'MariaDB 10.0' do
+      it 'Packages with the correct name' do
+        expect(mariadb_client_package.package_name).to eq 'rh-mariadb100-mariadb'
+        expect(mariadb_devel_package.package_name).to eq 'rh-mariadb100-mariadb-devel'
+      end
+    end
+
+    context 'MariaDB 5.5' do
+      cached(:chef_run) do
+        runner = ChefSpec::ServerRunner.new(
+          platform: 'centos', version: '6.0',
+          step_into: ['mariadb_configuration']
+        ) do |node|
+          node.automatic['memory']['total'] = '2048kB'
+          node.automatic['ipaddress'] = '1.1.1.1'
+          node.override['mariadb']['install']['prefer_scl_package'] = true
+          node.override['mariadb']['install']['version'] = '5.5'
+        end
+        runner.converge('mariadb::client')
+      end
+
+      it 'Packages with the correct name' do
+        expect(mariadb_client_package.package_name).to eq 'mariadb55-mariadb'
+        expect(mariadb_devel_package.package_name).to eq 'mariadb55-mariadb-devel'
+      end
+    end
+
+    context 'MariaDB 10.1' do
+      cached(:chef_run) do
+        runner = ChefSpec::ServerRunner.new(
+          platform: 'centos', version: '6.0',
+          step_into: ['mariadb_configuration']
+        ) do |node|
+          node.automatic['memory']['total'] = '2048kB'
+          node.automatic['ipaddress'] = '1.1.1.1'
+          node.override['mariadb']['install']['prefer_scl_package'] = true
+          node.override['mariadb']['install']['version'] = '10.1'
+        end
+        runner.converge('mariadb::client')
+      end
+      it 'Packages with the correct name' do
+        expect(mariadb_client_package.package_name).to eq 'rh-mariadb101-mariadb'
+        expect(mariadb_devel_package.package_name).to eq 'rh-mariadb101-mariadb-devel'
+      end
+    end
+  end
+
+  context 'Installation from SCL repository (centos 7)' do
     cached(:chef_run) do
       runner = ChefSpec::ServerRunner.new(
         platform: 'centos', version: '7.0',
@@ -288,6 +359,7 @@ describe 'centos::mariadb::client' do
       end
       runner.converge('mariadb::client')
     end
+
     let(:mariadb_client_package) { chef_run.package('MariaDB-client') }
     let(:mariadb_devel_package) { chef_run.package('MariaDB-devel') }
 
@@ -296,7 +368,7 @@ describe 'centos::mariadb::client' do
     end
 
     it 'Remove mysql-libs package' do
-      expect(chef_run).to remove_package('mysql-libs')
+      expect(chef_run).to_not remove_package('mysql-libs')
     end
 
     context 'MariaDB 10.0' do
@@ -319,6 +391,7 @@ describe 'centos::mariadb::client' do
         end
         runner.converge('mariadb::client')
       end
+
       it 'Packages with the correct name' do
         expect(mariadb_client_package.package_name).to eq 'mariadb55-mariadb'
         expect(mariadb_devel_package.package_name).to eq 'mariadb55-mariadb-devel'


### PR DESCRIPTION
When mariadb is installed with a package at a version different than
the default os one, during removal of mysql-libs with yum multiple
matches can be found but chef could only use the first match:
MariaDB-compat. Therefore, because of dependencies, the removal of
MariaDB-compat triggers the one of MariaDB-server and several other
packages (MariaDB-shared, MariaDB-client, MariaDB-common, MariaDB-devel,
MySQL-python). To fix this issue we prevent the removal of mysql-libs
for centos-7 and later.

Signed-off-by: Jean-Francois Weber-Marx <jf.webermarx@criteo.com>