### PR TITLE
Pin 12.19.36 tests, allow Chef 13 tests to fail for now

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -2,7 +2,7 @@
 driver:
   name: dokken
   privileged: true # because Docker and SystemD/Upstart
-  chef_version: current
+  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
 
 transport:
   name: dokken

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,50 +20,95 @@ services: docker
 env:
   matrix:
   - INSTANCE=default-centos-6
+  - INSTANCE=default-centos-6 CHEF_VERSION=12.19.36
   - INSTANCE=default-centos-7
+  - INSTANCE=default-centos-7 CHEF_VERSION=12.19.36
   - INSTANCE=default-debian-7
+  - INSTANCE=default-debian-7 CHEF_VERSION=12.19.36
   - INSTANCE=default-debian-8
+  - INSTANCE=default-debian-8 CHEF_VERSION=12.19.36
   - INSTANCE=default-ubuntu-1404
+  - INSTANCE=default-ubuntu-1404 CHEF_VERSION=12.19.36
   - INSTANCE=default-ubuntu-1604
+  - INSTANCE=default-ubuntu-1604 CHEF_VERSION=12.19.36
   - INSTANCE=native-centos-7
-  - INSTANCE=scl-centos-7
+  - INSTANCE=native-centos-7 CHEF_VERSION=12.19.36
   - INSTANCE=scl-centos-6
+  - INSTANCE=scl-centos-6 CHEF_VERSION=12.19.36
+  - INSTANCE=scl-centos-7
+  - INSTANCE=scl-centos-7 CHEF_VERSION=12.19.36
   - INSTANCE=replication-centos-6
+  - INSTANCE=replication-centos-6 CHEF_VERSION=12.19.36
   - INSTANCE=replication-centos-7
+  - INSTANCE=replication-centos-7 CHEF_VERSION=12.19.36
   - INSTANCE=replication-debian-7
+  - INSTANCE=replication-debian-7 CHEF_VERSION=12.19.36
   - INSTANCE=replication-debian-8
+  - INSTANCE=replication-debian-8 CHEF_VERSION=12.19.36
   - INSTANCE=replication-ubuntu-1404
+  - INSTANCE=replication-ubuntu-1404 CHEF_VERSION=12.19.36
   - INSTANCE=replication-ubuntu-1604
+  - INSTANCE=replication-ubuntu-1604 CHEF_VERSION=12.19.36
   - INSTANCE=galera-centos-6
+  - INSTANCE=galera-centos-6 CHEF_VERSION=12.19.36
   - INSTANCE=galera-centos-7
+  - INSTANCE=galera-centos-7 CHEF_VERSION=12.19.36
   - INSTANCE=galera-debian-7
+  - INSTANCE=galera-debian-7 CHEF_VERSION=12.19.36
   - INSTANCE=galera-debian-8
+  - INSTANCE=galera-debian-8 CHEF_VERSION=12.19.36
   - INSTANCE=galera-ubuntu-1404
+  - INSTANCE=galera-ubuntu-1404 CHEF_VERSION=12.19.36
   - INSTANCE=galera-ubuntu-1604
+  - INSTANCE=galera-ubuntu-1604 CHEF_VERSION=12.19.36
   - INSTANCE=datadir-changed-centos-6
+  - INSTANCE=datadir-changed-centos-6 CHEF_VERSION=12.19.36
   - INSTANCE=datadir-changed-centos-7
+  - INSTANCE=datadir-changed-centos-7 CHEF_VERSION=12.19.36
   - INSTANCE=datadir-changed-debian-7
+  - INSTANCE=datadir-changed-debian-7 CHEF_VERSION=12.19.36
   - INSTANCE=datadir-changed-debian-8
+  - INSTANCE=datadir-changed-debian-8 CHEF_VERSION=12.19.36
   - INSTANCE=datadir-changed-ubuntu-1404
+  - INSTANCE=datadir-changed-ubuntu-1404 CHEF_VERSION=12.19.36
   - INSTANCE=datadir-changed-ubuntu-1604
+  - INSTANCE=datadir-changed-ubuntu-1604 CHEF_VERSION=12.19.36
   - INSTANCE=port-changed-centos-6
+  - INSTANCE=port-changed-centos-6 CHEF_VERSION=12.19.36
   - INSTANCE=port-changed-centos-7
+  - INSTANCE=port-changed-centos-7 CHEF_VERSION=12.19.36
   - INSTANCE=port-changed-debian-7
+  - INSTANCE=port-changed-debian-7 CHEF_VERSION=12.19.36
   - INSTANCE=port-changed-debian-8
+  - INSTANCE=port-changed-debian-8 CHEF_VERSION=12.19.36
   - INSTANCE=port-changed-ubuntu-1404
+  - INSTANCE=port-changed-ubuntu-1404 CHEF_VERSION=12.19.36
   - INSTANCE=port-changed-ubuntu-1604
+  - INSTANCE=port-changed-ubuntu-1604 CHEF_VERSION=12.19.36
   - INSTANCE=plugins-centos-6
+  - INSTANCE=plugins-centos-6 CHEF_VERSION=12.19.36
   - INSTANCE=plugins-centos-7
+  - INSTANCE=plugins-centos-7 CHEF_VERSION=12.19.36
   - INSTANCE=plugins-debian-7
+  - INSTANCE=plugins-debian-7 CHEF_VERSION=12.19.36
   - INSTANCE=plugins-debian-8
+  - INSTANCE=plugins-debian-8 CHEF_VERSION=12.19.36
   - INSTANCE=plugins-ubuntu-1404
+  - INSTANCE=plugins-ubuntu-1404 CHEF_VERSION=12.19.36
   - INSTANCE=plugins-ubuntu-1604
+  - INSTANCE=plugins-ubuntu-1604 CHEF_VERSION=12.19.36
   - INSTANCE=no-binlog-centos-6
+  - INSTANCE=no-binlog-centos-6 CHEF_VERSION=12.19.36
   - INSTANCE=no-binlog-centos-7
+  - INSTANCE=no-binlog-centos-7 CHEF_VERSION=12.19.36
   - INSTANCE=no-binlog-debian-7
+  - INSTANCE=no-binlog-debian-7 CHEF_VERSION=12.19.36
   - INSTANCE=no-binlog-debian-8
+  - INSTANCE=no-binlog-debian-8 CHEF_VERSION=12.19.36
   - INSTANCE=no-binlog-ubuntu-1404
+  - INSTANCE=no-binlog-ubuntu-1404 CHEF_VERSION=12.19.36
   - INSTANCE=no-binlog-ubuntu-1604
+  - INSTANCE=no-binlog-ubuntu-1604 CHEF_VERSION=12.19.36
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
@@ -75,6 +120,52 @@ before_script:
 script: KITCHEN_LOCAL_YAML=.kitchen.dokken.yml /opt/chefdk/embedded/bin/kitchen verify ${INSTANCE}
 
 matrix:
+  allow_failures:
+    - env: INSTANCE=default-centos-6
+    - env: INSTANCE=default-centos-7
+    - env: INSTANCE=default-debian-7
+    - env: INSTANCE=default-debian-8
+    - env: INSTANCE=default-ubuntu-1404
+    - env: INSTANCE=default-ubuntu-1604
+    - env: INSTANCE=native-centos-7
+    - env: INSTANCE=scl-centos-7
+    - env: INSTANCE=scl-centos-6
+    - env: INSTANCE=replication-centos-6
+    - env: INSTANCE=replication-centos-7
+    - env: INSTANCE=replication-debian-7
+    - env: INSTANCE=replication-debian-8
+    - env: INSTANCE=replication-ubuntu-1404
+    - env: INSTANCE=replication-ubuntu-1604
+    - env: INSTANCE=galera-centos-6
+    - env: INSTANCE=galera-centos-7
+    - env: INSTANCE=galera-debian-7
+    - env: INSTANCE=galera-debian-8
+    - env: INSTANCE=galera-ubuntu-1404
+    - env: INSTANCE=galera-ubuntu-1604
+    - env: INSTANCE=datadir-changed-centos-6
+    - env: INSTANCE=datadir-changed-centos-7
+    - env: INSTANCE=datadir-changed-debian-7
+    - env: INSTANCE=datadir-changed-debian-8
+    - env: INSTANCE=datadir-changed-ubuntu-1404
+    - env: INSTANCE=datadir-changed-ubuntu-1604
+    - env: INSTANCE=port-changed-centos-6
+    - env: INSTANCE=port-changed-centos-7
+    - env: INSTANCE=port-changed-debian-7
+    - env: INSTANCE=port-changed-debian-8
+    - env: INSTANCE=port-changed-ubuntu-1404
+    - env: INSTANCE=port-changed-ubuntu-1604
+    - env: INSTANCE=plugins-centos-6
+    - env: INSTANCE=plugins-centos-7
+    - env: INSTANCE=plugins-debian-7
+    - env: INSTANCE=plugins-debian-8
+    - env: INSTANCE=plugins-ubuntu-1404
+    - env: INSTANCE=plugins-ubuntu-1604
+    - env: INSTANCE=no-binlog-centos-6
+    - env: INSTANCE=no-binlog-centos-7
+    - env: INSTANCE=no-binlog-debian-7
+    - env: INSTANCE=no-binlog-debian-8
+    - env: INSTANCE=no-binlog-ubuntu-1404
+    - env: INSTANCE=no-binlog-ubuntu-1604
   include:
     - script:
       - /opt/chefdk/bin/chef exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Removed
+
+- Remove Fedora support, tested versions are long gone EOL and hard to support; only latest version has a repo on yum.mariadb.org
+
 ## 1.3.0 (2017-03-20)
 
 ### Added

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,6 +1,6 @@
 # platform dependent attributes
 case node['platform']
-when 'redhat', 'centos', 'fedora', 'scientific', 'amazon'
+when 'redhat', 'centos', 'scientific', 'amazon'
   default['mariadb']['configuration']['path'] = '/etc'
   default['mariadb']['configuration']['includedir'] = '/etc/my.cnf.d'
   default['mariadb']['mysqld']['socket'] = '/var/lib/mysql/mysql.sock'

--- a/libraries/mariadb_helper.rb
+++ b/libraries/mariadb_helper.rb
@@ -40,8 +40,6 @@ module MariaDB
       case os_platform
       when 'centos', 'redhat'
         package_provided = true if os_version.to_i == 7
-      when 'fedora'
-        package_provided = true if os_version.to_i >= 19
       end
       package_provided
     end
@@ -55,8 +53,6 @@ module MariaDB
       case os_platform
       when 'centos', 'redhat', 'scientific'
         package_provided = true if os_version.to_i >= 6
-      when 'fedora'
-        package_provided = true if os_version.to_i >= 19
       end
       package_provided
     end
@@ -141,7 +137,7 @@ module MariaDB
     # @param [String] os_platform Indicate operating system type, e.g. centos
     def native_packages_names(os_platform)
       case os_platform
-      when 'redhat', 'centos', 'scientific', 'fedora'
+      when 'redhat', 'centos', 'scientific'
         { 'devel' => 'mariadb-devel',
           'client' => 'mariadb',
           'server' => 'mariadb-server' }
@@ -207,8 +203,6 @@ module MariaDB
     def mariadb_service_name(os_platform, os_version, mariadb_version, prefer_os, prefer_scl)
       if use_os_native_package?(prefer_os, os_platform, os_version)
         case os_platform
-        when 'fedora'
-          os_version.to_i >= 19 ? 'mysqld' : 'mysql'
         when 'redhat', 'centos', 'scientific', 'debian', 'ubuntu'
           'mariadb'
         end

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,6 +6,7 @@ description 'Installs/Configures MariaDB'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/sinfomicien/mariadb' if respond_to?(:source_url)
 issues_url 'https://github.com/sinfomicien/mariadb/issues' if respond_to?(:issues_url)
+chef_version '>= 12.6' if respond_to?(:chef_version)
 version '1.3.0'
 
 supports 'ubuntu'

--- a/recipes/client.rb
+++ b/recipes/client.rb
@@ -27,7 +27,7 @@ when 'package'
 
   # Include RH specific recipe
   include_recipe "#{cookbook_name}::_redhat_client" if \
-    %w(redhat centos fedora scientific amazon).include?(node['platform'])
+    %w(redhat centos scientific amazon).include?(node['platform'])
 
   # Install client package
   client_package_name = packages_names_to_install(node['platform'],

--- a/recipes/galera.rb
+++ b/recipes/galera.rb
@@ -55,7 +55,7 @@ when 'package'
   case node['platform']
   when 'debian', 'ubuntu'
     include_recipe "#{cookbook_name}::_debian_galera"
-  when 'redhat', 'centos', 'fedora', 'scientific', 'amazon'
+  when 'redhat', 'centos', 'scientific', 'amazon'
     include_recipe "#{cookbook_name}::_redhat_galera"
   end
 when 'from_source'

--- a/recipes/repository.rb
+++ b/recipes/repository.rb
@@ -1,7 +1,7 @@
 case node['platform']
 when 'debian', 'ubuntu'
   install_method = 'apt'
-when 'redhat', 'centos', 'fedora', 'scientific', 'amazon'
+when 'redhat', 'centos', 'scientific', 'amazon'
   install_method = 'yum'
 end
 

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -42,7 +42,7 @@ when 'package'
   case node['platform']
   when 'debian', 'ubuntu'
     include_recipe "#{cookbook_name}::_debian_server"
-  when 'redhat', 'centos', 'fedora', 'scientific', 'amazon'
+  when 'redhat', 'centos', 'scientific', 'amazon'
     include_recipe "#{cookbook_name}::_redhat_server"
   end
 

--- a/spec/centos_spec.rb
+++ b/spec/centos_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'centos::mariadb::default' do
-  let(:chef_run) do
+  cached(:chef_run) do
     runner = ChefSpec::ServerRunner.new(
       platform: 'centos', version: '6.4',
       step_into: ['mariadb_configuration']
@@ -101,7 +101,7 @@ describe 'centos::mariadb::default' do
   end
 
   context 'Installation from OS repository' do
-    let(:chef_run) do
+    cached(:chef_run) do
       runner = ChefSpec::ServerRunner.new(
         platform: 'centos', version: '7.0',
         step_into: ['mariadb_configuration']
@@ -122,29 +122,10 @@ describe 'centos::mariadb::default' do
     it 'Package with the correct name' do
       expect(mariadb_package.package_name).to eq 'mariadb-server'
     end
-
-    context 'Fedora 19 from OS repository has different service name' do
-      let(:chef_run) do
-        runner = ChefSpec::ServerRunner.new(
-          platform: 'fedora', version: '19',
-          step_into: ['mariadb_configuration']
-        ) do |node|
-          node.automatic['memory']['total'] = '2048kB'
-          node.automatic['ipaddress'] = '1.1.1.1'
-          node.override['mariadb']['install']['prefer_os_package'] = true
-        end
-        runner.converge('mariadb::default')
-      end
-      let(:mariadb_service) { chef_run.service('mysql') }
-
-      it 'MariaDB service with the correct name' do
-        expect(mariadb_service.service_name).to eq 'mysqld'
-      end
-    end
   end
 
   context 'Installation from SCL repository' do
-    let(:chef_run) do
+    cached(:chef_run) do
       runner = ChefSpec::ServerRunner.new(
         platform: 'centos', version: '7.0',
         step_into: ['mariadb_configuration']
@@ -173,7 +154,7 @@ describe 'centos::mariadb::default' do
     end
 
     context 'MariaDB 5.5' do
-      let(:chef_run) do
+      cached(:chef_run) do
         runner = ChefSpec::ServerRunner.new(
           platform: 'centos', version: '7.0',
           step_into: ['mariadb_configuration']
@@ -198,7 +179,7 @@ describe 'centos::mariadb::default' do
     end
 
     context 'MariaDB 10.1' do
-      let(:chef_run) do
+      cached(:chef_run) do
         runner = ChefSpec::ServerRunner.new(
           platform: 'centos', version: '7.0',
           step_into: ['mariadb_configuration']
@@ -225,7 +206,7 @@ describe 'centos::mariadb::default' do
 end
 
 describe 'centos::mariadb::client' do
-  let(:chef_run) do
+  cached(:chef_run) do
     runner = ChefSpec::ServerRunner.new(
       platform: 'centos', version: '6.4',
       step_into: ['mariadb_configuration']
@@ -275,7 +256,7 @@ describe 'centos::mariadb::client' do
   end
 
   context 'Installation from OS repository' do
-    let(:chef_run) do
+    cached(:chef_run) do
       runner = ChefSpec::ServerRunner.new(
         platform: 'centos', version: '7.0',
         step_into: ['mariadb_configuration']
@@ -296,7 +277,7 @@ describe 'centos::mariadb::client' do
   end
 
   context 'Installation from SCL repository' do
-    let(:chef_run) do
+    cached(:chef_run) do
       runner = ChefSpec::ServerRunner.new(
         platform: 'centos', version: '7.0',
         step_into: ['mariadb_configuration']
@@ -326,7 +307,7 @@ describe 'centos::mariadb::client' do
     end
 
     context 'MariaDB 5.5' do
-      let(:chef_run) do
+      cached(:chef_run) do
         runner = ChefSpec::ServerRunner.new(
           platform: 'centos', version: '7.0',
           step_into: ['mariadb_configuration']
@@ -345,7 +326,7 @@ describe 'centos::mariadb::client' do
     end
 
     context 'MariaDB 10.1' do
-      let(:chef_run) do
+      cached(:chef_run) do
         runner = ChefSpec::ServerRunner.new(
           platform: 'centos', version: '7.0',
           step_into: ['mariadb_configuration']
@@ -365,7 +346,7 @@ describe 'centos::mariadb::client' do
   end
 
   context 'Without development files' do
-    let(:chef_run) do
+    cached(:chef_run) do
       runner = ChefSpec::ServerRunner.new(
         platform: 'centos', version: '6.4',
         step_into: ['mariadb_configuration']

--- a/spec/debian_galera10_spec.rb
+++ b/spec/debian_galera10_spec.rb
@@ -134,7 +134,7 @@ describe 'debian::mariadb::galera10-xtrabackup-v2' do
       node.default['mariadb']['galera']['cluster_name'] = 'galera_cluster'
     end
   end
-  let(:chef_run) do
+  cached(:chef_run) do
     runner = ChefSpec::ServerRunner.new(
       platform: 'debian', version: '7.4',
       step_into: ['mariadb_configuration']

--- a/spec/debian_galera55_spec.rb
+++ b/spec/debian_galera55_spec.rb
@@ -15,7 +15,7 @@ describe 'debian::mariadb::galera55' do
       node.default['mariadb']['galera']['cluster_name'] = 'galera_cluster'
     end
   end
-  let(:chef_run) do
+  cached(:chef_run) do
     runner = ChefSpec::ServerRunner.new(
       platform: 'debian', version: '7.4',
       step_into: ['mariadb_configuration']

--- a/spec/debian_spec.rb
+++ b/spec/debian_spec.rb
@@ -8,7 +8,7 @@ describe 'debian::mariadb::default' do
     )
   end
 
-  let(:chef_run) do
+  cached(:chef_run) do
     runner = ChefSpec::SoloRunner.new(
       platform: 'debian', version: '7.4',
       step_into: ['mariadb_configuration']
@@ -83,7 +83,7 @@ describe 'debian::mariadb::default' do
 end
 
 describe 'debian::mariadb::client' do
-  let(:chef_run) do
+  cached(:chef_run) do
     runner = ChefSpec::SoloRunner.new(
       platform: 'debian', version: '7.4',
       step_into: ['mariadb_configuration']
@@ -102,7 +102,7 @@ describe 'debian::mariadb::client' do
     expect(chef_run).to install_package('libmariadbclient-dev')
   end
   context 'Without development files' do
-    let(:chef_run) do
+    cached(:chef_run) do
       runner = ChefSpec::SoloRunner.new(
         platform: 'debian', version: '7.4',
         step_into: ['mariadb_configuration']

--- a/spec/unit/helper_spec.rb
+++ b/spec/unit/helper_spec.rb
@@ -47,10 +47,9 @@ describe MariaDB::Helper do
     let(:dummy_helper) { dummy_class.new }
 
     context 'os package provided' do
-      let(:support_platforms) do
+      let(:supported_platforms) do
         Hash['redhat' => %w(7.0 7.1),
              'centos' => %w(7.0),
-             'fedora' => %w(19 20 21)
         ]
       end
       let(:support_mariadb) do
@@ -58,7 +57,7 @@ describe MariaDB::Helper do
       end
 
       it 'os_package_provided to be true' do
-        support_platforms.each do |platform, ver_list|
+        supported_platforms.each do |platform, ver_list|
           ver_list.each do |version|
             expect(
               dummy_helper.os_package_provided?(
@@ -70,7 +69,7 @@ describe MariaDB::Helper do
       end
 
       it 'use native package' do
-        support_platforms.each do |platform, ver_list|
+        supported_platforms.each do |platform, ver_list|
           ver_list.each do |version|
             expect(
               dummy_helper.use_os_native_package?(
@@ -87,18 +86,14 @@ describe MariaDB::Helper do
       end
 
       it 'mariadb service name' do
-        support_platforms.each do |platform, ver_list|
+        supported_platforms.each do |platform, ver_list|
           ver_list.each do |version|
             support_mariadb.each do |mariadb_version|
               expect(
                 dummy_helper.mariadb_service_name(
                   platform, version, mariadb_version, true, false
                 )
-              ).to eq(if platform == 'fedora' && version.to_i >= 19
-                        'mysqld'
-                      else
-                        'mariadb'
-                      end)
+              ).to eq('mariadb')
             end
           end
         end
@@ -106,10 +101,9 @@ describe MariaDB::Helper do
     end
 
     context 'os package not provided' do
-      let(:unsupport_platforms) do
+      let(:unsupported_platforms) do
         Hash['redhat' => %w(5.5 6.4 6.5),
              'centos' => %w(5.4 6.6),
-             'fedora' => %w(17 18),
              'ubuntu' => %w(11.04 12.04 14.04),
              'debian' => %w(7.8)
         ]
@@ -119,7 +113,7 @@ describe MariaDB::Helper do
       end
 
       it 'os_package_provided to be false' do
-        unsupport_platforms.each do |platform, ver_list|
+        unsupported_platforms.each do |platform, ver_list|
           ver_list.each do |version|
             expect(
               dummy_helper.os_package_provided?(
@@ -131,7 +125,7 @@ describe MariaDB::Helper do
       end
 
       it 'mariadb service falls back to default' do
-        unsupport_platforms.each do |platform, ver_list|
+        unsupported_platforms.each do |platform, ver_list|
           ver_list.each do |version|
             support_mariadb.each do |mariadb_version|
               expect(
@@ -147,7 +141,7 @@ describe MariaDB::Helper do
       it 'cannot use native package' do
         warn_called = false
         allow(Chef::Log).to receive(:warn) { warn_called = true }
-        unsupport_platforms.each do |platform, ver_list|
+        unsupported_platforms.each do |platform, ver_list|
           ver_list.each do |version|
             warn_called = false
             expect(
@@ -175,7 +169,7 @@ describe MariaDB::Helper do
     let(:dummy_helper) { dummy_class.new }
 
     context 'scl package provided' do
-      let(:support_platforms) do
+      let(:supported_platforms) do
         Hash['centos' => %w(6.8 7.0),
              'scientific' => %w(6.8),
         ]
@@ -185,7 +179,7 @@ describe MariaDB::Helper do
       end
 
       it 'os_package_provided to be true' do
-        support_platforms.each do |platform, ver_list|
+        supported_platforms.each do |platform, ver_list|
           ver_list.each do |version|
             expect(
               dummy_helper.scl_package_provided?(
@@ -196,7 +190,7 @@ describe MariaDB::Helper do
         end
       end
       it 'use scl package' do
-        support_platforms.each do |platform, ver_list|
+        supported_platforms.each do |platform, ver_list|
           ver_list.each do |version|
             expect(
               dummy_helper.use_scl_package?(
@@ -212,7 +206,7 @@ describe MariaDB::Helper do
         end
       end
       it 'mariadb service name' do
-        support_platforms.each do |platform, ver_list|
+        supported_platforms.each do |platform, ver_list|
           ver_list.each do |version|
             support_mariadb.each do |mariadb_version|
               expect(
@@ -234,10 +228,9 @@ describe MariaDB::Helper do
     end
 
     context 'scl package not provided' do
-      let(:unsupport_platforms) do
+      let(:unsupported_platforms) do
         Hash['redhat' => %w(5.5 5.6),
              'centos' => %w(5.2 5.7),
-             'fedora' => %w(17 18),
         ]
       end
       let(:support_mariadb) do
@@ -245,7 +238,7 @@ describe MariaDB::Helper do
       end
 
       it 'scl_package_provided to be false' do
-        unsupport_platforms.each do |platform, ver_list|
+        unsupported_platforms.each do |platform, ver_list|
           ver_list.each do |version|
             expect(
               dummy_helper.scl_package_provided?(
@@ -257,7 +250,7 @@ describe MariaDB::Helper do
       end
 
       it 'mariadb service falls back to default' do
-        unsupport_platforms.each do |platform, ver_list|
+        unsupported_platforms.each do |platform, ver_list|
           ver_list.each do |version|
             support_mariadb.each do |mariadb_version|
               expect(
@@ -273,7 +266,7 @@ describe MariaDB::Helper do
       it 'cannot use scl package' do
         warn_called = false
         allow(Chef::Log).to receive(:warn) { warn_called = true }
-        unsupport_platforms.each do |platform, ver_list|
+        unsupported_platforms.each do |platform, ver_list|
           ver_list.each do |version|
             warn_called = false
             expect(

--- a/test/integration/datadir_changed/serverspec/install_spec.rb
+++ b/test/integration/datadir_changed/serverspec/install_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 package_server_name = 'mariadb-server-10.0'
 case os[:family]
-when 'fedora', 'centos', 'redhat'
+when 'centos', 'redhat'
   package_server_name = 'MariaDB-server'
 end
 

--- a/test/integration/datadir_changed/serverspec/mariadb_spec.rb
+++ b/test/integration/datadir_changed/serverspec/mariadb_spec.rb
@@ -12,7 +12,7 @@ end
 includedir = '/etc/mysql/conf.d'
 mysql_config_file = '/etc/mysql/my.cnf'
 case os[:family]
-when 'fedora', 'centos', 'redhat'
+when 'centos', 'redhat'
   includedir = '/etc/my.cnf.d'
   mysql_config_file = '/etc/my.cnf'
 end

--- a/test/integration/default/serverspec/install_spec.rb
+++ b/test/integration/default/serverspec/install_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 package_server_name = 'mariadb-server-10.0'
 case os[:family]
-when 'fedora', 'centos', 'redhat'
+when 'centos', 'redhat'
   package_server_name = 'MariaDB-server'
 end
 

--- a/test/integration/default/serverspec/mariadb_spec.rb
+++ b/test/integration/default/serverspec/mariadb_spec.rb
@@ -12,7 +12,7 @@ end
 includedir = '/etc/mysql/conf.d'
 mysql_config_file = '/etc/mysql/my.cnf'
 case os[:family]
-when 'fedora', 'centos', 'redhat'
+when 'centos', 'redhat'
   includedir = '/etc/my.cnf.d'
   mysql_config_file = '/etc/my.cnf'
 end

--- a/test/integration/galera/serverspec/install_spec.rb
+++ b/test/integration/galera/serverspec/install_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 package_server_name = 'mariadb-galera-server-10.0'
 case os[:family]
-when 'fedora', 'centos', 'redhat'
+when 'centos', 'redhat'
   package_server_name = 'MariaDB-Galera-server'
 end
 

--- a/test/integration/galera/serverspec/mariadb_spec.rb
+++ b/test/integration/galera/serverspec/mariadb_spec.rb
@@ -12,7 +12,7 @@ end
 includedir = '/etc/mysql/conf.d'
 mysql_config_file = '/etc/mysql/my.cnf'
 case os[:family]
-when 'fedora', 'centos', 'redhat'
+when 'centos', 'redhat'
   includedir = '/etc/my.cnf.d'
   mysql_config_file = '/etc/my.cnf'
 end

--- a/test/integration/native/serverspec/install_spec.rb
+++ b/test/integration/native/serverspec/install_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 package_server_name = 'mariadb-server-10.0'
 case os[:family]
-when 'fedora', 'centos', 'redhat'
+when 'centos', 'redhat'
   package_server_name = 'mariadb-server'
 end
 

--- a/test/integration/native/serverspec/mariadb_spec.rb
+++ b/test/integration/native/serverspec/mariadb_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
 
-service_name = 'mariadb'
-service_name = 'mysqld' if os[:family] == 'fedora' && os[:release].to_i == 19
-
-describe service(service_name) do
+describe service('mariadb') do
   it { should be_enabled }
   it { should be_running }
 end
@@ -15,7 +12,7 @@ end
 includedir = '/etc/mysql/conf.d'
 mysql_config_file = '/etc/mysql/my.cnf'
 case os[:family]
-when 'fedora', 'centos', 'redhat'
+when 'centos', 'redhat'
   includedir = '/etc/my.cnf.d'
   mysql_config_file = '/etc/my.cnf'
 end

--- a/test/integration/no_binlog/serverspec/install_spec.rb
+++ b/test/integration/no_binlog/serverspec/install_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 package_server_name = 'mariadb-server-10.0'
 case os[:family]
-when 'fedora', 'centos', 'redhat'
+when 'centos', 'redhat'
   package_server_name = 'MariaDB-server'
 end
 

--- a/test/integration/no_binlog/serverspec/mariadb_spec.rb
+++ b/test/integration/no_binlog/serverspec/mariadb_spec.rb
@@ -12,7 +12,7 @@ end
 includedir = '/etc/mysql/conf.d'
 mysql_config_file = '/etc/mysql/my.cnf'
 case os[:family]
-when 'fedora', 'centos', 'redhat'
+when 'centos', 'redhat'
   includedir = '/etc/my.cnf.d'
   mysql_config_file = '/etc/my.cnf'
 end

--- a/test/integration/plugins/serverspec/install_spec.rb
+++ b/test/integration/plugins/serverspec/install_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 package_server_name = 'mariadb-server-10.0'
 case os[:family]
-when 'fedora', 'centos', 'redhat'
+when 'centos', 'redhat'
   package_server_name = 'MariaDB-server'
 end
 

--- a/test/integration/port_changed/serverspec/install_spec.rb
+++ b/test/integration/port_changed/serverspec/install_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 package_server_name = 'mariadb-server-10.0'
 case os[:family]
-when 'fedora', 'centos', 'redhat'
+when 'centos', 'redhat'
   package_server_name = 'MariaDB-server'
 end
 

--- a/test/integration/port_changed/serverspec/mariadb_spec.rb
+++ b/test/integration/port_changed/serverspec/mariadb_spec.rb
@@ -12,7 +12,7 @@ end
 includedir = '/etc/mysql/conf.d'
 mysql_config_file = '/etc/mysql/my.cnf'
 case os[:family]
-when 'fedora', 'centos', 'redhat'
+when 'centos', 'redhat'
   includedir = '/etc/my.cnf.d'
   mysql_config_file = '/etc/my.cnf'
 end

--- a/test/integration/replication/serverspec/install_spec.rb
+++ b/test/integration/replication/serverspec/install_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 package_server_name = 'mariadb-server-10.0'
 case os[:family]
-when 'fedora', 'centos', 'redhat'
+when 'centos', 'redhat'
   package_server_name = 'MariaDB-server'
 end
 


### PR DESCRIPTION
Add specific test for 12.19.36 and allow tests against current (Chef 13 now) to fail until this cookbook is Chef 13 ready.