### PR TITLE
Add resources to manage databases and users

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -157,3 +157,14 @@ suites:
         use_default_repository: true
         replication:
           log_bin: false
+
+  #
+  # resources to manage databases and users
+  #
+  - name: resources
+    run_list:
+      - recipe[mariadb_test::resources]
+    attributes:
+      mariadb:
+        server_root_password: gsql
+        use_default_repository: true

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -117,3 +117,13 @@ suites:
         use_default_repository: true
         replication:
           log_bin: false
+  #
+  # resources to manage databases and users
+  #
+  - name: resources
+    run_list:
+      - recipe[mariadb_test::resources]
+    attributes:
+      mariadb:
+        server_root_password: gsql
+        use_default_repository: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,6 +65,13 @@ env:
   - INSTANCE=no-binlog-debian-8 CHEF_VERSION=12.19.36
   - INSTANCE=no-binlog-ubuntu-1604
   - INSTANCE=no-binlog-ubuntu-1604 CHEF_VERSION=12.19.36
+  - INSTANCE=resources-centos-7
+  - INSTANCE=resources-centos-7 CHEF_VERSION=12.19.36
+  - INSTANCE=resources-debian-8
+  - INSTANCE=resources-debian-8 CHEF_VERSION=12.19.36
+  - INSTANCE=resources-ubuntu-1604
+  - INSTANCE=resources-ubuntu-1604 CHEF_VERSION=12.19.36
+
 
 before_script:
   - sudo iptables -L DOCKER || ( echo "DOCKER iptables chain missing" ; sudo iptables -N DOCKER )
@@ -100,6 +107,9 @@ matrix:
     - env: INSTANCE=no-binlog-centos-7
     - env: INSTANCE=no-binlog-debian-8
     - env: INSTANCE=no-binlog-ubuntu-1604
+    - env: INSTANCE=resources-centos-7
+    - env: INSTANCE=resources-debian-8
+    - env: INSTANCE=resources-ubuntu-1604
   include:
     - script:
       - /opt/chefdk/bin/chef exec rake

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+### Added
+
+- Added resource `mariadb_database` to manage databases ([#187](https://github.com/sous-chefs/mariadb/pull/187))
+- Added resource `mariadb_user` to manage users and privileges ([#187](https://github.com/sous-chefs/mariadb/pull/187))
+
 ## 1.5.3 (2017-10-13)
 
 This cookbook was transferred to Sous Chefs.

--- a/libraries/hashed_password.rb
+++ b/libraries/hashed_password.rb
@@ -1,0 +1,44 @@
+#
+# Author:: Maksim Horbul (<max@gorbul.net>)
+# Cookbook:: mariadb
+# Library:: hashed_password
+#
+# Copyright:: 2016, Eligible, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class HashedPassword
+  # Initializes an object of the MysqlPassword type
+  # @param [String] hashed_password mysql native hashed password
+  # @return [MysqlPassword]
+  def initialize(hashed_password)
+    @hashed_password = hashed_password
+  end
+
+  # String representation of the object
+  # @return [String] hashed password string
+  def to_s
+    @hashed_password
+  end
+
+  module Helper
+    # helper method wrappers the string into a MysqlPassword object
+    # @param [String] hashed_password mysql native hashed password
+    # @return [MysqlPassword] object
+    def hashed_password(hashed_password)
+      HashedPassword.new hashed_password
+    end
+    # For backward compatibility, because method was renamed
+    alias_method :mysql_hashed_password, :hashed_password
+  end
+end

--- a/libraries/mariadb_conn_helper.rb
+++ b/libraries/mariadb_conn_helper.rb
@@ -6,11 +6,13 @@ module MariaDB
     module Helper
       def initialize(new_resource, run_context)
         super
+        @connection_pool ||= {}
+        return if run_context.instance_variable_get(:@mysql2_gem_installed)
         mysql2_gem 'mysql2' do
           compile_time true
           action :install
         end
-        @connection_pool ||= {}
+        run_context.instance_variable_set(:@mysql2_gem_installed, true)
       end
 
       def connect(host:, port: '3306', username:, password: nil, socket: nil)

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -38,7 +38,7 @@ template node['mariadb']['configuration']['path'] + '/my.cnf' do
   owner 'root'
   group 'root'
   mode '0644'
-  notifies :create, 'ruby_block[restart_mysql]', :immediately unless no_mysql_restart_rc
+  notifies :run, 'ruby_block[restart_mysql]', :immediately unless no_mysql_restart_rc
 end
 
 directory '/etc/my.cnf.d/' do
@@ -94,7 +94,7 @@ mariadb_configuration '20-innodb' do
   section 'mysqld'
   option innodb_options
   action :add
-  notifies :create, 'ruby_block[restart_mysql]', :immediately unless no_mysql_restart_rc
+  notifies :run, 'ruby_block[restart_mysql]', :immediately unless no_mysql_restart_rc
 end
 
 replication_opts = {}
@@ -122,5 +122,5 @@ mariadb_configuration '30-replication' do
   section 'mysqld'
   option replication_opts
   action :add
-  notifies :create, 'ruby_block[restart_mysql]', :immediately unless no_mysql_restart_rc
+  notifies :run, 'ruby_block[restart_mysql]', :immediately unless no_mysql_restart_rc
 end

--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -56,7 +56,7 @@ when 'package'
   package 'MariaDB-server' do
     package_name server_package_name
     action :install
-    notifies :create, 'ruby_block[restart_mysql]', :immediately
+    notifies :run, 'ruby_block[restart_mysql]', :immediately
   end
 
 end
@@ -102,7 +102,7 @@ if node['mariadb']['mysqld']['datadir'] !=
     action :create
     notifies :stop, 'service[mysql]', :immediately
     notifies :run, 'bash[move-datadir]', :immediately
-    notifies :create, 'ruby_block[restart_mysql]', :immediately
+    notifies :run, 'ruby_block[restart_mysql]', :immediately
     only_if { !File.symlink?(node['mariadb']['mysqld']['default_datadir']) }
   end
 end
@@ -121,7 +121,7 @@ execute 'mariadb-service-restart-needed' do
       node['mariadb']['mysqld']['socket']
     )
   end
-  notifies :create, 'ruby_block[restart_mysql]', :immediately
+  notifies :run, 'ruby_block[restart_mysql]', :immediately
 end
 
 # Service definition allowing timely restart

--- a/resources/database.rb
+++ b/resources/database.rb
@@ -1,0 +1,80 @@
+#
+# Cookbook Name:: mariadb
+# Resource:: database
+#
+
+default_action :create
+
+property :database_name, kind_of: String, name_attribute: true
+property :host, kind_of: [String, NilClass], default: 'localhost', desired_state: false
+property :port, kind_of: [String, NilClass], default: node['mariadb']['mysqld']['port'].to_s, desired_state: false
+property :user, kind_of: [String, NilClass], default: 'root', desired_state: false
+property :password, kind_of: [String, NilClass], default: node['mariadb']['server_root_password'], sensitive: true, desired_state: false
+property :encoding, kind_of: String, default: 'utf8'
+property :collation, kind_of: String, default: 'utf8_general_ci'
+property :sql, kind_of: [String, Proc]
+
+action_class do
+  include MariaDB::Connection::Helper
+
+  def run_query(query)
+    socket = if node['mariadb']['client']['socket'] && new_resource.host == 'localhost'
+               node['mariadb']['client']['socket']
+             end
+    connect(host: new_resource.host, port: new_resource.port, username: new_resource.user, password: new_resource.password, socket: socket) unless connected?(new_resource.host, new_resource.user)
+    raw_query = query.is_a?(Proc) ? query.call : query
+    Chef::Log.info("#{new_resource.name}: Performing query [#{raw_query}]")
+    query(new_resource.host, new_resource.user, raw_query)
+  end
+end
+
+load_current_value do
+  require 'mysql2'
+  socket = if node['mariadb']['client']['socket'] && host == 'localhost'
+             node['mariadb']['client']['socket']
+           end
+  conn_options = { username: user, password: password,
+                   port: port }.merge!(socket.nil? ? { host: host } : { socket: socket })
+  begin
+    mysql_connection = Mysql2::Client.new(conn_options)
+    results = mysql_connection.query("SHOW DATABASES LIKE '#{database_name}'")
+    current_value_does_not_exist! if results.count == 0
+
+    results = mysql_connection.query("SELECT DEFAULT_CHARACTER_SET_NAME, DEFAULT_COLLATION_NAME FROM information_schema.SCHEMATA WHERE SCHEMA_NAME = '#{database_name}'")
+    results.each do |row|
+      encoding row['DEFAULT_CHARACTER_SET_NAME']
+      collation row['DEFAULT_COLLATION_NAME']
+    end
+  ensure
+    mysql_connection.close
+  end
+end
+
+action :create do
+  if current_resource.nil?
+    converge_by "Creating database '#{new_resource.database_name}'" do
+      create_sql = "CREATE DATABASE IF NOT EXISTS `#{new_resource.database_name}`"
+      create_sql += " CHARACTER SET = #{new_resource.encoding}" if new_resource.encoding
+      create_sql += " COLLATE = #{new_resource.collation}" if new_resource.collation
+      run_query create_sql
+    end
+  else
+    converge_if_changed :encoding do
+      run_query "ALTER SCHEMA '#{new_resource.database_name}' CHARACTER SET = #{encoding}"
+    end
+    converge_if_changed :collation do
+      run_query "ALTER SCHEMA '#{new_resource.database_name}' COLLATE = #{collation}"
+    end
+  end
+end
+
+action :drop do
+  return if current_resource.nil?
+  converge_by "Dropping database '#{new_resource.database_name}'" do
+    run_query "DROP DATABASE IF EXISTS `#{new_resource.database_name}`"
+  end
+end
+
+action :query do
+  run_query new_resource.sql
+end

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -293,7 +293,6 @@ action :revoke do
       Chef::Log.debug("#{@new_resource}: revoking access with statement [#{revoke_statement}]")
       run_query revoke_statement
       run_query 'FLUSH PRIVILEGES'
-      @new_resource.updated_by_last_action(true)
     end
   end
 end

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -1,0 +1,299 @@
+#
+# Cookbook Name:: mariadb
+# Resource:: user
+#
+
+default_action :create
+
+property :username, kind_of: String, name_attribute: true
+property :password, kind_of: [String, HashedPassword], sensitive: true
+property :host, kind_of: String, default: 'localhost'
+property :database_name, String
+property :table, String
+property :privileges, Array, default: [:all]
+property :grant_option, [TrueClass, FalseClass], default: false
+property :require_ssl, [TrueClass, FalseClass], default: false
+property :require_x509, [TrueClass, FalseClass], default: false
+# Credentials used for control connection
+property :ctrl_user, kind_of: [String, NilClass], default: 'root', desired_state: false
+property :ctrl_password, kind_of: [String, NilClass], default: node['mariadb']['server_root_password'], sensitive: true, desired_state: false
+property :ctrl_host, kind_of: [String, NilClass], default: 'localhost', desired_state: false
+property :ctrl_port, kind_of: [String, NilClass], default: node['mariadb']['mysqld']['port'].to_s, desired_state: false
+
+action_class do
+  include MariaDB::Connection::Helper
+
+  def run_query(query)
+    socket = if node['mariadb']['client']['socket'] && new_resource.ctrl_host == 'localhost'
+               node['mariadb']['client']['socket']
+             end
+    unless connected?(new_resource.ctrl_host, new_resource.ctrl_user)
+      connect(host: new_resource.ctrl_host, port: new_resource.ctrl_port, username: new_resource.ctrl_user, password: new_resource.ctrl_password, socket: socket)
+    end
+    raw_query = query.is_a?(Proc) ? query.call : query
+    Chef::Log.debug("#{@new_resource}: Performing query [#{raw_query}]")
+    query(new_resource.ctrl_host, new_resource.ctrl_user, raw_query)
+  end
+
+  def database_has_password_column
+    run_query('SHOW COLUMNS FROM mysql.user WHERE Field="Password"').count > 0
+  end
+
+  def redact_password(query, password)
+    if password.nil? || password == ''
+      query
+    else
+      query.gsub(password.to_s, 'REDACTED')
+    end
+  end
+
+  def test_user_password
+    if database_has_password_column
+      test_sql = 'SELECT User,Host,Password FROM mysql.user ' \
+                       "WHERE User='#{new_resource.username}' AND Host='#{new_resource.host}' "
+      test_sql += if new_resource.password.is_a? HashedPassword
+                    "AND Password='#{new_resource.password}'"
+                  else
+                    "AND Password=PASSWORD('#{new_resource.password}')"
+                  end
+    else
+      test_sql = 'SELECT User,Host,authentication_string FROM mysql.user ' \
+                       "WHERE User='#{new_resource.username}' AND Host='#{new_resource.host}' " \
+                       "AND plugin='mysql_native_password' "
+      test_sql += if new_resource.password.is_a? HashedPassword
+                    "AND authentication_string='#{new_resource.password}'"
+                  else
+                    "AND authentication_string=PASSWORD('#{new_resource.password}')"
+                  end
+    end
+    run_query(test_sql).count > 0
+  end
+
+  def update_user_password
+    converge_by "Update password for user '#{new_resource.username}'@'#{new_resource.host}'" do
+      if database_has_password_column
+        password_sql = "SET PASSWORD FOR '#{new_resource.username}'@'#{new_resource.host}' = "
+        password_sql += if new_resource.password.is_a? HashedPassword
+                          "'#{new_resource.password}'"
+                        else
+                          " PASSWORD('#{new_resource.password}')"
+                        end
+      else
+        # "ALTER USER is now the preferred statement for assigning passwords."
+        # http://dev.mysql.com/doc/refman/5.7/en/set-password.html
+        password_sql = "ALTER USER '#{new_resource.username}'@'#{new_resource.host}' "
+        password_sql += if new_resource.password.is_a? HashedPassword
+                          "IDENTIFIED WITH mysql_native_password AS '#{new_resource.password}'"
+                        else
+                          "IDENTIFIED BY '#{new_resource.password}'"
+                        end
+      end
+      run_query password_sql
+    end
+  end
+
+  def desired_privs
+    possible_global_privs = [
+      :select,
+      :insert,
+      :update,
+      :delete,
+      :create,
+      :drop,
+      :references,
+      :index,
+      :alter,
+      :create_tmp_table,
+      :lock_tables,
+      :create_view,
+      :show_view,
+      :create_routine,
+      :alter_routine,
+      :execute,
+      :event,
+      :trigger,
+      :reload,
+      :shutdown,
+      :process,
+      :file,
+      :show_db,
+      :super,
+      :repl_slave,
+      :repl_client,
+      :create_user,
+    ]
+    possible_db_privs = [
+      :select,
+      :insert,
+      :update,
+      :delete,
+      :create,
+      :drop,
+      :references,
+      :index,
+      :alter,
+      :create_tmp_table,
+      :lock_tables,
+      :create_view,
+      :show_view,
+      :create_routine,
+      :alter_routine,
+      :execute,
+      :event,
+      :trigger,
+    ]
+
+    # convert :all to the individual db or global privs
+    desired_privs = if new_resource.privileges == [:all] && new_resource.database_name
+                      possible_db_privs
+                    elsif new_resource.privileges == [:all]
+                      possible_global_privs
+                    else
+                      new_resource.privileges
+                    end
+    desired_privs
+  end
+
+  def revokify_key(key)
+    return '' if key.nil?
+
+    # Some keys need to be translated as outlined by the table found here:
+    # https://dev.mysql.com/doc/refman/5.7/en/privileges-provided.html
+    result = key.to_s.downcase.tr('_', ' ').gsub('repl ', 'replication ').gsub('create tmp table', 'create temporary tables').gsub('show db', 'show databases')
+    result = result.gsub(/ priv$/, '')
+    result
+  end
+end
+
+load_current_value do
+  require 'mysql2'
+  socket = if node['mariadb']['client']['socket'] && host == 'localhost'
+             node['mariadb']['client']['socket']
+           end
+  conn_options = { username: ctrl_user,
+                   password: ctrl_password,
+                   port: ctrl_port.to_s,
+                 }.merge!(socket.nil? ? { host: ctrl_host } : { socket: socket })
+  begin
+    mysql_connection = Mysql2::Client.new(conn_options)
+    results = mysql_connection.query("SELECT User,Host FROM mysql.user WHERE User='#{username}' AND Host='#{host}';")
+    current_value_does_not_exist! if results.count == 0
+  ensure
+    mysql_connection.close
+  end
+end
+
+action :create do
+  if current_resource.nil?
+    converge_by "Creating user '#{new_resource.username}'@'#{new_resource.host}'" do
+      create_sql = "CREATE USER '#{new_resource.username}'@'#{new_resource.host}'"
+      if new_resource.password
+        create_sql += ' IDENTIFIED BY '
+        create_sql += if new_resource.password.is_a?(HashedPassword)
+                        " PASSWORD '#{new_resource.password}'"
+                      else
+                        " '#{new_resource.password}'"
+                      end
+      end
+      run_query create_sql
+    end
+  elsif !test_user_password
+    update_user_password
+  end
+end
+
+action :drop do
+  return if current_resource.nil?
+  converge_by "Dropping user '#{new_resource.username}'@'#{new_resource.host}'" do
+    drop_sql = 'DROP USER'
+    drop_sql += " '#{new_resource.username}'@'#{new_resource.host}'"
+    run_query drop_sql
+  end
+end
+
+action :grant do
+  db_name = new_resource.database_name ? "`#{new_resource.database_name}`" : '*'
+  tbl_name = new_resource.table ? new_resource.table : '*'
+  test_table = new_resource.database_name ? 'mysql.db' : 'mysql.user'
+
+  # Test
+  incorrect_privs = nil
+  test_sql = "SELECT * from #{test_table}"
+  test_sql += " WHERE User='#{new_resource.username}'"
+  test_sql += " AND Host='#{new_resource.host}'"
+  test_sql += " AND Db='#{new_resource.database_name}'" if new_resource.database_name
+  test_sql_results = run_query test_sql
+
+  incorrect_privs = true if test_sql_results.count == 0
+  # These should all be 'Y'
+  test_sql_results.each do |r|
+    desired_privs.each do |p|
+      key = p.to_s.capitalize.tr(' ', '_').gsub('Replication_', 'Repl_').gsub('Create_temporary_tables', 'Create_tmp_table').gsub('Show_databases', 'Show_db')
+      key = "#{key}_priv"
+      incorrect_privs = true if r[key] != 'Y'
+    end
+  end
+
+  password_up_to_date = incorrect_privs || test_user_password
+
+  # Repair
+  if incorrect_privs
+    converge_by "Granting privs for '#{new_resource.username}'@'#{new_resource.host}'" do
+      repair_sql = "GRANT #{new_resource.privileges.join(',')}"
+      repair_sql += " ON #{db_name}.#{tbl_name}"
+      repair_sql += " TO '#{new_resource.username}'@'#{new_resource.host}' IDENTIFIED BY"
+      repair_sql += if new_resource.password.is_a?(HashedPassword)
+                      " PASSWORD '#{new_resource.password}'"
+                    else
+                      " '#{new_resource.password}'"
+                    end
+      repair_sql += ' REQUIRE SSL' if new_resource.require_ssl
+      repair_sql += ' REQUIRE X509' if new_resource.require_x509
+      repair_sql += ' WITH GRANT OPTION' if new_resource.grant_option
+
+      redacted_sql = redact_password(repair_sql, new_resource.password)
+      Chef::Log.debug("#{@new_resource}: granting with sql [#{redacted_sql}]")
+      run_query(repair_sql)
+      run_query('FLUSH PRIVILEGES')
+    end
+  else
+    # The grants are correct, but perhaps the password needs updating?
+    update_user_password unless password_up_to_date
+  end
+end
+
+action :revoke do
+  db_name = new_resource.database_name ? "`#{new_resource.database_name}`" : '*'
+  tbl_name = new_resource.table ? new_resource.table : '*'
+  test_table = new_resource.database_name ? 'mysql.db' : 'mysql.user'
+
+  privs_to_revoke = []
+  test_sql = "SELECT * from #{test_table}"
+  test_sql += " WHERE User='#{new_resource.username}'"
+  test_sql += " AND Host='#{new_resource.host}'"
+  test_sql += " AND Db='#{new_resource.database_name}'" if new_resource.database_name
+  test_sql_results = run_query test_sql
+
+  # These should all be 'N'
+  test_sql_results.each do |r|
+    desired_privs.each do |p|
+      key = p.to_s.capitalize.tr(' ', '_').gsub('Replication_', 'Repl_').gsub('Create_temporary_tables', 'Create_tmp_table').gsub('Show_databases', 'Show_db')
+      key = "#{key}_priv"
+      privs_to_revoke << revokify_key(p) if r[key] != 'N'
+    end
+  end
+
+  # Repair
+  unless privs_to_revoke.empty?
+    converge_by "Revoking privs for '#{new_resource.username}'@'#{new_resource.host}'" do
+      revoke_statement = "REVOKE #{privs_to_revoke.join(',')}"
+      revoke_statement += " ON #{db_name}.#{tbl_name}"
+      revoke_statement += " FROM `#{new_resource.username}`@`#{new_resource.host}` "
+
+      Chef::Log.debug("#{@new_resource}: revoking access with statement [#{revoke_statement}]")
+      run_query revoke_statement
+      run_query 'FLUSH PRIVILEGES'
+      @new_resource.updated_by_last_action(true)
+    end
+  end
+end

--- a/test/fixtures/cookbooks/mariadb_test/recipes/resources.rb
+++ b/test/fixtures/cookbooks/mariadb_test/recipes/resources.rb
@@ -1,0 +1,129 @@
+::Chef::Recipe.send(:include, HashedPassword::Helper)
+
+include_recipe 'mariadb::server'
+
+# Create a schema to test mysql_database :drop against
+bash 'create datatrout' do
+  code <<-EOF
+  echo 'CREATE SCHEMA datatrout;' | /usr/bin/mysql -u root -pgsql;
+  touch /tmp/troutmarker
+  EOF
+  not_if 'test -f /tmp/troutmarker'
+  action :run
+end
+
+# Create a database for testing existing grant operations
+bash 'create datasalmon' do
+  code <<-EOF
+  echo 'CREATE SCHEMA datasalmon;' | /usr/bin/mysql -u root -pgsql;
+  touch /tmp/salmonmarker
+  EOF
+  not_if 'test -f /tmp/salmonmarker'
+  action :run
+end
+
+# Create a user to test mysql_database_user :drop against
+bash 'create kermit' do
+  code <<-EOF
+  echo "CREATE USER 'kermit'@'localhost';" | /usr/bin/mysql -u root -pgsql;
+  touch /tmp/kermitmarker
+  EOF
+  not_if 'test -f /tmp/kermitmarker'
+  action :run
+end
+
+# Create a user to test mysql_database_user password update via :create
+bash 'create rowlf' do
+  code <<-EOF
+  echo "CREATE USER 'rowlf'@'localhost' IDENTIFIED BY 'hunter2';" | /usr/bin/mysql -u root -pgsql;
+  touch /tmp/rowlfmarker
+  EOF
+  not_if 'test -f /tmp/rowlfmarker'
+  action :run
+end
+
+# Create a user to test mysql_database_user password update via :create using a password hash
+bash 'create statler' do
+  code <<-EOF
+  echo "CREATE USER 'statler'@'localhost' IDENTIFIED BY 'hunter2';" | /usr/bin/mysql -u root -pgsql;
+  touch /tmp/statlermarker
+  EOF
+  not_if 'test -f /tmp/statlermarker'
+  action :run
+end
+
+# Create a user to test mysql_database_user password update via :grant
+bash 'create rizzo' do
+  code <<-EOF
+  echo "GRANT SELECT ON datasalmon.* TO 'rizzo'@'127.0.0.1' IDENTIFIED BY 'hunter2';" | /usr/bin/mysql -u root -pgsql;
+  touch /tmp/rizzomarker
+  EOF
+  not_if 'test -f /tmp/rizzomarker'
+  action :run
+end
+
+## Resources we're testing
+mariadb_database 'databass' do
+  action :create
+end
+
+mariadb_database 'datatrout' do
+  action :drop
+end
+
+mariadb_user 'piggy' do
+  action :create
+end
+
+mariadb_user 'kermit' do
+  action :drop
+end
+
+mariadb_user 'rowlf' do
+  password '123456' # hashed: *6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9
+  action :create
+end
+
+hash = hashed_password('*2027D9391E714343187E07ACB41AE8925F30737E'); # 'l33t'
+
+mariadb_user 'statler' do
+  password hash
+  action :create
+end
+
+mariadb_user 'fozzie' do
+  database_name 'databass'
+  password 'wokkawokka'
+  host 'mars'
+  privileges [:select, :update, :insert]
+  require_ssl true
+  action :grant
+end
+
+hash2 = hashed_password('*F798E7C0681068BAE3242AA2297D2360DBBDA62B'); # 'zokkazokka'
+
+mariadb_user 'moozie' do
+  database_name 'databass'
+  password hash2
+  host '127.0.0.1'
+  privileges [:select, :update, :insert]
+  require_ssl false
+  action :grant
+end
+
+# all the grants exist ('Granting privs' should not show up), but the password is different
+# and should get updated
+mariadb_user 'rizzo' do
+  database_name 'datasalmon'
+  password 'salmon'
+  host '127.0.0.1'
+  privileges [:select]
+  require_ssl false
+  action :grant
+end
+
+mariadb_database 'flush privileges' do
+  database_name 'databass'
+  sql 'flush privileges'
+  action :query
+end

--- a/test/integration/resources/inspec/database_spec.rb
+++ b/test/integration/resources/inspec/database_spec.rb
@@ -1,0 +1,11 @@
+control 'mariadb_database' do
+  impact 1.0
+  title 'test creation and removal of databases'
+
+  sql = mysql_session('root', 'gsql')
+
+  describe sql.query('show databases') do
+    its(:stdout) { should match(/databass/) }
+    its(:stdout) { should_not match(/datatrout/) }
+  end
+end

--- a/test/integration/resources/inspec/user_spec.rb
+++ b/test/integration/resources/inspec/user_spec.rb
@@ -1,0 +1,37 @@
+control 'mariadb_user' do
+  impact 1.0
+  title 'test creation, granting and removal of users'
+
+  sql = mysql_session('root', 'gsql')
+
+  describe sql.query('select User,Host from mysql.user') do
+    its(:stdout) { should match(/fozzie/) }
+    its(:stdout) { should_not match(/kermit/) }
+  end
+
+  describe sql.query('select Password from mysql.user where User like \'fozzie\'') do
+    its(:stdout) { should contain '*EF112B3D562CB63EA3275593C10501B59C4A390D' }
+  end
+
+  describe sql.query('select Password from mysql.user where User like \'moozie\'') do
+    its(:stdout) { should contain '*F798E7C0681068BAE3242AA2297D2360DBBDA62B' }
+  end
+
+  sql2 = mysql_session('moozie', 'zokkazokka', '127.0.0.1')
+
+  describe sql2.query('show tables from databass') do
+    its(:exit_status) { should eq 0 }
+  end
+
+  describe sql.query('select Password from mysql.user where User like \'rowlf\'') do
+    its(:stdout) { should contain '*6BB4837EB74329105EE4568DDA7DC67ED2CA2AD9' }
+  end
+
+  describe sql.query('select Password from mysql.user where User like \'statler\'') do
+    its(:stdout) { should contain '*2027D9391E714343187E07ACB41AE8925F30737E' }
+  end
+
+  describe sql.query('select Password from mysql.user where User like \'rizzo\'') do
+    its(:stdout) { should contain '*125EA03B506F7C876D9321E9055F37601461E970' }
+  end
+end


### PR DESCRIPTION
This adds 2 new Custom Resources `mariadb_database` to manage databases and run queries on them, and `mariadb_user` to grant access to users. This used to be provided by the now deprecated [`database`](https://supermarket.chef.io/cookbooks/database) cookbook.

## Usage example
```
mariadb_database 'databass' do
  action :create
end

mariadb_database 'datatrout' do
  action :drop
end

mariadb_user 'fozzie' do
  database_name 'databass'
  password 'wokkawokka'
  host 'mars'
  privileges [:select, :update, :insert]
  action :grant
end

mariadb_database 'flush privileges' do
  database_name 'databass'
  sql 'flush privileges'
  action :query
end
```
The resources use the `mysql2` gem (automatically installed when missing) to established a control  connection to the MariaDB server (by default as root@localhost using password).

Integration tests are included using Inspec.

I haven't updated the README yet, I'm waiting for maintainers' approval first.