### PR TITLE
#186 Fix libmariadbclient-dev not available on Ubuntu 16.04

### DIFF
--- a/libraries/mariadb_helper.rb
+++ b/libraries/mariadb_helper.rb
@@ -166,11 +166,17 @@ module MariaDB
     # Helper to determine names of mariadb packages provided by MariaDB
     # @param [String] os_platform Indicate operating system type, e.g. centos
     # @param [String] version Indicate requested version of mariadb
-    def mariadb_packages_names(os_platform, version)
+    def mariadb_packages_names(os_platform, os_version, version)
       if %w(debian ubuntu).include?(os_platform)
-        { 'devel' => 'libmariadbclient-dev',
-          'client' => "mariadb-client-#{version}",
-          'server' => "mariadb-server-#{version}" }
+        if Gem::Version.new(os_version) >= Gem::Version.new('16.00')
+          { 'devel' => 'libmariadb-client-lgpl-dev',
+            'client' => "mariadb-client-#{version}",
+            'server' => "mariadb-server-#{version}" }
+        else
+          { 'devel' => 'libmariadbclient-dev',
+            'client' => "mariadb-client-#{version}",
+            'server' => "mariadb-server-#{version}" }
+        end
       else
         { 'devel' => 'MariaDB-devel',
           'client' => 'MariaDB-client',
@@ -190,7 +196,7 @@ module MariaDB
       elsif use_scl_package?(prefer_scl, os_platform, os_version)
         scl_packages_names(os_platform, mariadb_version)
       else
-        mariadb_packages_names(os_platform, mariadb_version)
+        mariadb_packages_names(os_platform, os_version, mariadb_version)
       end
     end
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 source_url 'https://github.com/sous-chefs/mariadb' if respond_to?(:source_url)
 issues_url 'https://github.com/sous-chefs/mariadb/issues' if respond_to?(:issues_url)
 chef_version '>= 12.6' if respond_to?(:chef_version)
-version '1.5.3'
+version '1.5.4'
 
 supports 'ubuntu'
 supports 'debian', '>= 7.0'


### PR DESCRIPTION
This should fix #186. I'm not to sure about the difference between `native_packages_names()`, `scl_packages_names()`, and `mariadb_packages_names()`. It is possible that the others should have similar logic, but I don't understand the considerations that go into each branch of logic.