### PR TITLE
Correct galera 10.2

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -43,6 +43,18 @@ platforms:
       - RUN /usr/bin/apt-get update
       - RUN /usr/bin/apt-get install lsb-release net-tools sudo -y
 
+- name: debian-9
+  attributes:
+    mariadb:
+     install:
+       version: '10.2'
+  driver:
+    image: debian:9
+    pid_one_command: /bin/systemd
+    intermediate_instructions:
+      - RUN /usr/bin/apt-get update
+      - RUN /usr/bin/apt-get install lsb-release net-tools sudo -y
+
 - name: ubuntu-14.04
   driver:
     image: ubuntu-upstart:14.04
@@ -112,6 +124,21 @@ suites:
     attributes:
       mariadb:
         use_default_repository: true
+
+  #
+  # galera with mariabackup as SST method
+  #
+  - name: galera-mariabackup
+    run_list:
+      - recipe[mariadb::galera]
+    attributes:
+      mariadb:
+        use_default_repository: true
+        galera:
+          wsrep_sst_method: 'mariabackup'
+    includes:
+      - debian-9
+
   #
   # datadir_changed
   #

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -16,6 +16,11 @@ platforms:
           name: chef_zero
           require_chef_omnibus: 12
   - name: debian-8.7
+  - name: debian-9.4
+    attributes:
+      mariadb:
+        install:
+          version: '10.2'
   - name: ubuntu-14.04
   - name: ubuntu-16.04
 
@@ -72,6 +77,19 @@ suites:
     attributes:
       mariadb:
         use_default_repository: true
+  #
+  # galera with mariabackup as SST method
+  #
+  - name: galera-mariabackup
+    run_list:
+      - recipe[mariadb::galera]
+    attributes:
+      mariadb:
+        use_default_repository: true
+        galera:
+          wsrep_sst_method: 'mariabackup'
+    includes:
+      - debian-9.4
   #
   # datadir_changed
   #

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Requirements
 
 #### packages
 - `percona-xtrabackup` - if you want to use the xtrabckup SST Auth for galera cluster.
-- `socat` - if you want to use the xtrabckup SST Auth for galera cluster.
+- `mariadb-backup` - if you want to use the mariabackup SST Auth for galera cluster.
+- `socat` - if you want to use the xtrabckup or mariabackup SST Auth for galera cluster.
 - `rsync` - if you want to use the rsync SST Auth for galera cluster.
 - `debconf-utils` - if you use debian platform family.
 

--- a/libraries/mariadb_helper.rb
+++ b/libraries/mariadb_helper.rb
@@ -168,9 +168,15 @@ module MariaDB
     # @param [String] version Indicate requested version of mariadb
     def mariadb_packages_names(os_platform, version)
       if %w(debian ubuntu).include?(os_platform)
-        { 'devel' => 'libmariadbclient-dev',
-          'client' => "mariadb-client-#{version}",
-          'server' => "mariadb-server-#{version}" }
+        if version.to_f >= 10.2
+          { 'devel' => 'libmariadb-dev',
+            'client' => "mariadb-client-#{version}",
+            'server' => "mariadb-server-#{version}" }
+        else
+          { 'devel' => 'libmariadbclient-dev',
+            'client' => "mariadb-client-#{version}",
+            'server' => "mariadb-server-#{version}" }
+        end
       else
         { 'devel' => 'MariaDB-devel',
           'client' => 'MariaDB-client',

--- a/recipes/_debian_galera.rb
+++ b/recipes/_debian_galera.rb
@@ -35,7 +35,13 @@ rescue Chef::Exceptions::ResourceNotFound
   end
 end
 
-template '/var/cache/local/preseeding/mariadb-galera-server.seed' do
+preseed_file = if node['mariadb']['install']['version'].to_f >= 10.2
+                 '/var/cache/local/preseeding/mariadb-server-' + node['mariadb']['install']['version'] + '.seed'
+               else
+                 '/var/cache/local/preseeding/mariadb-galera-server.seed'
+               end
+
+template preseed_file do
   source 'mariadb-server.seed.erb'
   owner 'root'
   group 'root'
@@ -46,8 +52,7 @@ template '/var/cache/local/preseeding/mariadb-galera-server.seed' do
 end
 
 execute 'preseed mariadb-galera-server' do
-  command '/usr/bin/debconf-set-selections ' \
-          '/var/cache/local/preseeding/mariadb-galera-server.seed'
+  command '/usr/bin/debconf-set-selections ' + preseed_file
   action :nothing
 end
 

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -41,12 +41,12 @@ template node['mariadb']['configuration']['path'] + '/my.cnf' do
   notifies :run, 'ruby_block[restart_mysql]', :immediately unless no_mysql_restart_rc
 end
 
-directory '/etc/my.cnf.d/' do
+directory node['mariadb']['configuration']['includedir'] do
   owner 'root'
   group 'root'
   mode '0755'
   action :create
-  not_if { ::Dir.exist?('/etc/my.cnf.d/') }
+  not_if { ::Dir.exist?(node['mariadb']['configuration']['includedir']) }
 end
 
 innodb_options = {}

--- a/recipes/galera.rb
+++ b/recipes/galera.rb
@@ -79,6 +79,15 @@ if node['mariadb']['install']['extra_packages']
         action :install
       end
     end
+  elsif node['mariadb']['galera']['wsrep_sst_method'] == 'mariabackup'
+    package 'mariadb-backup-' + node['mariadb']['install']['version'] do
+      action :install
+    end
+    %w(socat pv).each do |pkg|
+      package pkg do
+        action :install
+      end
+    end
   end
 end
 
@@ -279,10 +288,10 @@ if platform?('debian', 'ubuntu')
 end
 
 #
-# Galera SST method xtrabackup will need a seperated mysql sstuser as root
+# Galera SST method xtrabackup (or mariabackup) will need a seperated mysql sstuser as root
 # should not be used.
 #
-if node['mariadb']['galera']['wsrep_sst_method'] =~ /^xtrabackup(-v2)?/
+if node['mariadb']['galera']['wsrep_sst_method'] =~ /^(maria|xtra)backup(-v2)?/
 
   sstuser, sstpassword = node['mariadb']['galera']['wsrep_sst_auth'].split(/:/)
 

--- a/templates/default/mariadb-server.seed.erb
+++ b/templates/default/mariadb-server.seed.erb
@@ -2,8 +2,8 @@
 # Value obtained via the debconf-get-selections tool on debian wheezy
 pack_w_version = @package_name + '-' + node['mariadb']['install']['version']
 -%>
-<%= pack_w_version %>	mysql-server/root_password_again	select	<%= node['mariadb']['server_root_password'] %>
-<%= pack_w_version %>	mysql-server/root_password	select	<%= node['mariadb']['server_root_password'] %>
+<%= pack_w_version %>	mysql-server/root_password_again	password	<%= node['mariadb']['server_root_password'] %>
+<%= pack_w_version %>	mysql-server/root_password	password	<%= node['mariadb']['server_root_password'] %>
 <%= pack_w_version %>	mysql-server/error_setting_password	boolean	false
 <%= pack_w_version %>	mysql-server-5.1/nis_warning	note
 <%= pack_w_version %>	mysql-server-5.1/start_on_boot	boolean	true


### PR DESCRIPTION
- It adds the mariabackup SST method support (#192)
- It installs correctly with preseed
- I tested with MariaDB 10.2
- Need another PR to be fully tested (#195), otherwise it will failed because dirmngr is missing and the key is not the good one. 