### PR TITLE
fixes #214

### DIFF
--- a/resources/client_install.rb
+++ b/resources/client_install.rb
@@ -22,7 +22,7 @@ property :setup_repo, [true, false], default: true
 action :install do
   mariadb_repository 'Add mariadb.org repository' do
     version new_resource.version
-    only_if { new_resource.setup_repo }
+    only_if { !new_resource.setup_repo.nil? }
   end
 
   case node['platform_family']

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -54,16 +54,14 @@ action :create do
 
   mariadb_root_password = new_resource.password == 'generate' || new_resource.password.nil? ? secure_random : new_resource.password
 
-  # Generate a ramdom password or set the a password defined with node['mariadb']['password']['root'].
+  # Generate a random password or set the a password defined with node['mariadb']['server_root_password'].
   # The password is set or change at each run. It is good for security if you choose to set a random password and
   # allow you to change the root password if needed.
-  bash 'generate-mariadb-root-password' do
+  execute 'generate-mariadb-root-password' do
     user 'root'
-    code <<-EOH
-    echo "ALTER USER 'root'@'localhost' IDENTIFIED BY \'#{mariadb_root_password}\';" | /usr/bin/mysql
-    EOH
+    command "/usr/bin/mysql -e \"ALTER USER 'root'@'localhost' IDENTIFIED BY '#{mariadb_root_password}';\""
     not_if { ::File.exist? "#{data_dir}/recovery.conf" }
-    only_if { new_resource.password }
+    only_if { !new_resource.password.nil? }
   end
 end
 

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -66,7 +66,6 @@ action :create do
     mode '600'
     sensitive true
     content "ALTER USER 'root'@'localhost' IDENTIFIED BY '#{mariadb_root_password}';"
-    action :create
     not_if { ::File.exist? "#{data_dir}/recovery.conf" }
   end
 

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -50,7 +50,7 @@ action :create do
   log 'Enable and start MariaDB service' do
     notifies :enable, "service[#{platform_service_name}]", :immediately
     notifies :stop, "service[#{platform_service_name}]", :immediately
-    notifies :run, 'file[generate-mariadb-root-password]', :immediately
+    notifies :create, 'file[generate-mariadb-root-password]', :immediately
     notifies :run, 'execute[apply-mariadb-root-password]', :immediately
     notifies :start, "service[#{platform_service_name}]", :immediately
   end

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -61,6 +61,7 @@ action :create do
   # The password is set or change at each run. It is good for security if you choose to set a random password and
   # allow you to change the root password if needed.
   file 'generate-mariadb-root-password' do
+    path "#{data_dir}/recovery.conf"
     owner 'root'
     group 'root'
     mode '600'


### PR DESCRIPTION
## Description

mariadb_server_install now sets up an initial root password, saves it in a root only r/w file and only sets up the root password if the file does not exist (maybe this method can be improved).
mariadb_client_install does not issue a warning about trying to execute a command on what would be a code block.

### Issues Resolved

#214 #220

### Check List
- [X] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
  tested with kitchen in Ubuntu 16.04 and 18.04, debian doesn't pass tests due to another issue with importing apt-keys (see https://github.com/chef/chef/issues/7913)
