### PR TITLE
fixes #214 #220

### DIFF
--- a/resources/client_install.rb
+++ b/resources/client_install.rb
@@ -22,7 +22,7 @@ property :setup_repo, [true, false], default: true
 action :install do
   mariadb_repository 'Add mariadb.org repository' do
     version new_resource.version
-    only_if { new_resource.setup_repo }
+    only_if { !new_resource.setup_repo.nil? }
   end
 
   case node['platform_family']

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -76,7 +76,7 @@ action :create do
   # make sure that mysqld is not running, and then set the root password
   execute 'apply-mariadb-root-password' do
     user 'root'
-    command "(test -f #{pid_file} && kill $(< #{pid_file})) || /usr/sbin/mysqld --init-file=#{data_dir}/recovery.conf&>/dev/null&"
+    command "(test -f #{pid_file} && kill $(< #{pid_file})); /usr/sbin/mysqld --init-file=#{data_dir}/recovery.conf&>/dev/null&"
     notifies :create, 'file[generate-mariadb-root-password]', :before
     notifies :start, "service[#{platform_service_name}]", :immediately
     notifies :run, 'execute[verify-root-password-okay]', :delayed

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -77,7 +77,7 @@ action :create do
   # make sure that mysqld is not running, and then set the root password
   execute 'apply-mariadb-root-password' do
     user 'root'
-    command "kill `cat #{pid_file}`; /usr/sbin/mysqld --init-file=#{data_dir}/recovery.conf&>/dev/null&"
+    command "(test -f #{pid_file} && kill $(< #{pid_file})); /usr/sbin/mysqld --init-file=#{data_dir}/recovery.conf&>/dev/null&"
     only_if { ::File.exist? "#{data_dir}/recovery.conf" }
     notifies :create, 'file[generate-mariadb-root-password]', :before
     notifies :run, 'execute[verify-root-password-okay]', :immediately
@@ -86,7 +86,7 @@ action :create do
   # make sure the password was properly set
   execute 'verify-root-password-okay' do
     user 'root'
-    command "mysql -p#{mariadb_root_password} -e '\s'&>/dev/null && kill `cat #{pid_file}`"
+    command "mysql -p#{mariadb_root_password} -e '\s'&>/dev/null && kill $(< #{pid_file})"
   end
 end
 

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -76,7 +76,7 @@ action :create do
   # make sure that mysqld is not running, and then set the root password
   execute 'apply-mariadb-root-password' do
     user 'root'
-    command "(test -f #{pid_file} && kill $(< #{pid_file})); /usr/sbin/mysqld --init-file=#{data_dir}/recovery.conf&>/dev/null&; sleep 2"
+    command "(test -f #{pid_file} && kill $(< #{pid_file})); /usr/sbin/mysqld --init-file=#{data_dir}/recovery.conf&>/dev/null&; sleep 2;"
     notifies :create, 'file[generate-mariadb-root-password]', :before
     notifies :start, "service[#{platform_service_name}]", :immediately
     notifies :run, "execute[verify-root-password-okay]", :delayed

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -50,7 +50,7 @@ action :create do
   log 'Enable and start MariaDB service' do
     notifies :enable, "service[#{platform_service_name}]", :immediately
     notifies :stop, "service[#{platform_service_name}]", :immediately
-    notifies :run, "execute[apply-mariadb-root-password]", :immediately
+    notifies :run, 'execute[apply-mariadb-root-password]', :immediately
   end
 
   # here we want to generate a new password if: 1- the user passed 'generate' to the password argument
@@ -79,7 +79,7 @@ action :create do
     command "(test -f #{pid_file} && kill $(< #{pid_file})) || /usr/sbin/mysqld --init-file=#{data_dir}/recovery.conf&>/dev/null&"
     notifies :create, 'file[generate-mariadb-root-password]', :before
     notifies :start, "service[#{platform_service_name}]", :immediately
-    notifies :run, "execute[verify-root-password-okay]", :delayed
+    notifies :run, 'execute[verify-root-password-okay]', :delayed
     action :nothing
   end
 

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -72,7 +72,7 @@ action :create do
 
   execute 'apply-mariadb-root-password' do
     user 'root'
-    command "/usr/sbin/mysqld --init-file=#{data_dir}/recovery.conf"
+    command "/usr/sbin/mysqld --user=root --init-file=#{data_dir}/recovery.conf"
     only_if { ::File.exist? "#{data_dir}/recovery.conf" }
   end
 end

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -76,7 +76,7 @@ action :create do
   # make sure that mysqld is not running, and then set the root password
   execute 'apply-mariadb-root-password' do
     user 'root'
-    command "(test -f #{pid_file} && kill $(< #{pid_file})); /usr/sbin/mysqld --init-file=#{data_dir}/recovery.conf&>/dev/null&; sleep 2;"
+    command "(test -f #{pid_file} && kill $(< #{pid_file})) || /usr/sbin/mysqld --init-file=#{data_dir}/recovery.conf&>/dev/null&"
     notifies :create, 'file[generate-mariadb-root-password]', :before
     notifies :start, "service[#{platform_service_name}]", :immediately
     notifies :run, "execute[verify-root-password-okay]", :delayed

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -50,9 +50,7 @@ action :create do
   log 'Enable and start MariaDB service' do
     notifies :enable, "service[#{platform_service_name}]", :immediately
     notifies :stop, "service[#{platform_service_name}]", :immediately
-    notifies :run, 'execute[apply-mariadb-root-password]', :immediately
-    notifies :start, "service[#{platform_service_name}]", :immediately
-    notifies :run, 'execute[verify-root-password-okay]', :immediately
+    notifies :run, "execute[apply-mariadb-root-password]", :immediately
   end
 
   # here we want to generate a new password if: 1- the user passed 'generate' to the password argument
@@ -81,6 +79,8 @@ action :create do
     command "(test -f #{pid_file} && kill $(< #{pid_file})); /usr/sbin/mysqld --init-file=#{data_dir}/recovery.conf&>/dev/null&; sleep 2"
     only_if { ::File.exist? "#{data_dir}/recovery.conf" }
     notifies :create, 'file[generate-mariadb-root-password]', :before
+    notifies :start, "service[#{platform_service_name}]", :immediately
+    notifies :run, "execute[verify-root-password-okay]", :delayed
     action :nothing
   end
 

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -54,16 +54,14 @@ action :create do
 
   mariadb_root_password = new_resource.password == 'generate' || new_resource.password.nil? ? secure_random : new_resource.password
 
-  # Generate a ramdom password or set the a password defined with node['mariadb']['password']['root'].
+  # Generate a random password or set the a password defined with node['mariadb']['server_root_password'].
   # The password is set or change at each run. It is good for security if you choose to set a random password and
   # allow you to change the root password if needed.
-  bash 'generate-mariadb-root-password' do
+  execute 'generate-mariadb-root-password' do
     user 'root'
-    code <<-EOH
-    echo "ALTER USER 'root'@'localhost' IDENTIFIED BY \'#{mariadb_root_password}\';" | /usr/bin/mysql
-    EOH
+    command "/usr/bin/mysql -e \"ALTER USER 'root'@'localhost' IDENTIFIED BY '#{mariadb_root_password}';\""
     not_if { ::File.exist? "#{data_dir}/recovery.conf" }
-    only_if { new_resource.password }
+    only_if { !new_resource.password.nil? }
   end
 end
 

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -66,7 +66,6 @@ action :create do
     mode '600'
     sensitive true
     content "ALTER USER 'root'@'localhost' IDENTIFIED BY '#{mariadb_root_password}';"
-    action :create
     not_if { ::File.exist? "#{data_dir}/recovery.conf" }
   end
 

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -80,7 +80,7 @@ action :create do
     command "kill `cat #{pid_file}`; /usr/sbin/mysqld --init-file=#{data_dir}/recovery.conf&>/dev/null&"
     only_if { ::File.exist? "#{data_dir}/recovery.conf" }
     notifies :create, 'file[generate-mariadb-root-password]', :before
-    notifies :run, 'execute[ensure-root-password-okay]', :immediately
+    notifies :run, 'execute[verify-root-password-okay]', :immediately
   end
 
   # make sure the password was properly set

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -50,7 +50,7 @@ action :create do
   log 'Enable and start MariaDB service' do
     notifies :enable, "service[#{platform_service_name}]", :immediately
     notifies :stop, "service[#{platform_service_name}]", :immediately
-    notifies :run, 'file[generate-mariadb-root-password]', :immediately
+    notifies :create, 'file[generate-mariadb-root-password]', :immediately
     notifies :run, 'execute[apply-mariadb-root-password]', :immediately
     notifies :start, "service[#{platform_service_name}]", :immediately
   end

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -86,7 +86,7 @@ action :create do
   # make sure the password was properly set
   execute 'verify-root-password-okay' do
     user 'root'
-    command "mysql -p#{mariadb_root_password} -e '\\s'&>/dev/null && kill $(< #{pid_file})"
+    command "mysql -p#{mariadb_root_password} -e '\\s'&>/dev/null && (test -f #{pid_file} && kill $(< #{pid_file}))"
   end
 end
 

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -77,7 +77,6 @@ action :create do
   execute 'apply-mariadb-root-password' do
     user 'root'
     command "(test -f #{pid_file} && kill $(< #{pid_file})); /usr/sbin/mysqld --init-file=#{data_dir}/recovery.conf&>/dev/null&; sleep 2"
-    only_if { ::File.exist? "#{data_dir}/recovery.conf" }
     notifies :create, 'file[generate-mariadb-root-password]', :before
     notifies :start, "service[#{platform_service_name}]", :immediately
     notifies :run, "execute[verify-root-password-okay]", :delayed

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -72,10 +72,12 @@ action :create do
     not_if { ::File.exist? "#{data_dir}/recovery.conf" }
   end
 
+  pid_file = default_pid_file.nil? ? '/var/run/mysql/mysqld.pid' : default_pid_file
+
   # make sure that mysqld is not running, and then set the root password
   execute 'apply-mariadb-root-password' do
     user 'root'
-    command "kill `cat #{external_pid_file}` && /usr/sbin/mysqld --init-file=#{data_dir}/recovery.conf&>/dev/null&"
+    command "kill `cat #{pid_file}`; /usr/sbin/mysqld --init-file=#{data_dir}/recovery.conf&>/dev/null&"
     only_if { ::File.exist? "#{data_dir}/recovery.conf" }
     notifies :create, 'file[generate-mariadb-root-password]', :before
     notifies :run, 'execute[ensure-root-password-okay]', :immediately
@@ -84,7 +86,7 @@ action :create do
   # make sure the password was properly set
   execute 'verify-root-password-okay' do
     user 'root'
-    command "mysql -p#{mariadb_root_password} -e '\s'&>/dev/null && kill `cat #{external_pid_file}`"
+    command "mysql -p#{mariadb_root_password} -e '\s'&>/dev/null && kill `cat #{pid_file}`"
   end
 end
 

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -61,6 +61,7 @@ action :create do
   # The password is set or change at each run. It is good for security if you choose to set a random password and
   # allow you to change the root password if needed.
   file 'generate-mariadb-root-password' do
+    path "#{data_dir}/recovery.conf"
     owner 'root'
     group 'root'
     mode '600'

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -86,7 +86,7 @@ action :create do
   # make sure the password was properly set
   execute 'verify-root-password-okay' do
     user 'root'
-    command "mysql -p#{mariadb_root_password} -e '\s'&>/dev/null && kill $(< #{pid_file})"
+    command "mysql -p#{mariadb_root_password} -e '\\s'&>/dev/null && kill $(< #{pid_file})"
   end
 end
 

--- a/test/cookbooks/test/recipes/server_install.rb
+++ b/test/cookbooks/test/recipes/server_install.rb
@@ -9,6 +9,6 @@ end
 find_resource(:service, 'mariadb') do
   extend MariaDBCookbook::Helpers
   service_name lazy { platform_service_name }
-  supports restart: true, status: true, reload: true
+  supports restart: true, status: true
   action [:enable, :start]
 end


### PR DESCRIPTION
## Description

Mainly fixes setting the root password in the server_install recipe. The way this is achieved is by first killing off any mysql service that may be running (and which are properly registered in /var/run/mysql/mysqld.pid), launching up a mysqld service manually, with an initial script which sets the root password. Then it tries to authenticate with that password, and if it is okay, it kills that process in order to allow the proper mariadb service to start.

Properly checks for the `node['mariadb']['server_root_password']` attribute being set, as well as the `password` property being passed. 

Fixes errors about the way the `only_if` guard is evaluated, it is now evaluated as a code block.

Also removed a reference in the integration tests about the `reload` function for mariadb service, which does not support this function.

### Issues Resolved

#214 #220 

### Check List
- [x] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
  tested with kitchen in Ubuntu 16.04 and 18.04, debian doesn't pass tests due to another issue with importing apt-keys (see chef/chef#7913)
- [x] New functionality includes testing.
  the testing is the recipe not failing by itself