### PR TITLE
Fixes #214 where root password for MariaDB is not actually updated.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- Updates password for the server root user via `node['mariadb']['server_root_password']`.
+
 ## 2.0.0
 
 ### Added

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -56,15 +56,14 @@ action :create do
   # Generate a ramdom password or set the a password defined with
   # node['mariadb']['server_root_password'].  The password is set or
   # change at each run. It is good for security if you choose to set a
-  # random password and allow you to change the root password if
-  # needed.  
+  # random password and allow you to change the root password if needed.
   mariadb_root_password = new_resource.password || secure_random
 
   statement = <<-EOH
 UPDATE user SET password=PASSWORD('#{mariadb_root_password}') WHERE User='root';
 FLUSH PRIVILEGES;
 EOH
-  
+
   bash 'apply-mariadb-root-password' do
     sensitive true
     user 'root'

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -27,10 +27,10 @@ property :grant_option,  [TrueClass, FalseClass],            default: false
 property :require_ssl,   [TrueClass, FalseClass],            default: false
 property :require_x509,  [TrueClass, FalseClass],            default: false
 # Credentials used for control connection
-property :ctrl_user,     [String, NilClass],                 default: 'root', desired_state: false
-property :ctrl_password, [String, NilClass],                 default: nil, sensitive: true, desired_state: false
-property :ctrl_host,     [String, NilClass],                 default: 'localhost', desired_state: false
-property :ctrl_port,     [Integer, NilClass],                default: 3306, desired_state: false
+property :ctrl_user,     [String, nil],                      default: 'root', desired_state: false
+property :ctrl_password, [String, nil],                      default: lazy { node['mariadb']['server_root_password'] }, sensitive: true, desired_state: false
+property :ctrl_host,     [String, nil],                      default: 'localhost', desired_state: false
+property :ctrl_port,     [Integer, nil],                     default: 3306, desired_state: false
 
 action :create do
   if current_resource.nil?
@@ -216,7 +216,7 @@ end
 
 action :grant do
   db_name = new_resource.database_name ? "\\`#{new_resource.database_name}\\`" : '*'
-  tbl_name = new_resource.table ? new_resource.table : '*'
+  tbl_name = new_resource.table || '*'
   test_table = new_resource.database_name ? 'mysql.db' : 'mysql.user'
 
   # Test
@@ -271,7 +271,7 @@ end
 
 action :revoke do
   db_name = new_resource.database_name ? "\\`#{new_resource.database_name}\\`" : '*'
-  tbl_name = new_resource.table ? new_resource.table : '*'
+  tbl_name = new_resource.table || '*'
   test_table = new_resource.database_name ? 'mysql.db' : 'mysql.user'
 
   privs_to_revoke = []


### PR DESCRIPTION
## Description

It seems that the previous syntax did not actually update the password
for the root user. After looking through pull-requests, I put together
this request to fix the issue after taking a look at
https://github.com/sous-chefs/mariadb/pull/234/files.

### Issues Resolved

#214 

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
