### PR TITLE
Don't specify privileges through symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ mariadb_user 'name' do
   host                       String # defaults to 'localhost'
   password                   String, HashedPassword
   # The privileges to be granted/revoked
-  privileges                 Array # defaults to [:all]
+  privileges                 Array # defaults to ["ALL PRIVILEGES"]
   database_name              String # to grant/revoke privileges on a database 
   table                      String # to grant/revoke privileges on a particular database table
   grant_option               true|false # defaults to false 
@@ -500,7 +500,7 @@ mariadb_user 'foo_user' do
   password 'super_secret'
   database_name 'foo'
   host '%'
-  privileges [:select,:update,:insert]
+  privileges ["SELECT","UPDATE","INSERT"]
   action :grant
 end
 ```

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -22,7 +22,7 @@ property :password,      [String, HashedPassword, NilClass], default: nil,  sens
 property :host,          String,                             default: 'localhost', desired_state: false
 property :database_name, String
 property :table,         String
-property :privileges,    Array,                              default: [:all]
+property :privileges,    Array,                              default: ['ALL PRIVILEGES']
 property :grant_option,  [TrueClass, FalseClass],            default: false
 property :require_ssl,   [TrueClass, FalseClass],            default: false
 property :require_x509,  [TrueClass, FalseClass],            default: false
@@ -183,10 +183,10 @@ action_class do
       :trigger,
     ]
 
-    # convert :all to the individual db or global privs
-    desired_privs = if new_resource.privileges == [:all] && new_resource.database_name
+    # convert "ALL PRIVILEGES" to the individual db or global privs
+    desired_privs = if (new_resource.privileges == ['ALL PRIVILEGES'] || new_resource.privileges == ['ALL']) && new_resource.database_name
                       possible_db_privs
-                    elsif new_resource.privileges == [:all]
+                    elsif new_resource.privileges == ['ALL PRIVILEGES'] || new_resource.privileges == ['ALL']
                       possible_global_privs
                     else
                       new_resource.privileges

--- a/test/cookbooks/test/recipes/user_database.rb
+++ b/test/cookbooks/test/recipes/user_database.rb
@@ -122,7 +122,7 @@ mariadb_user 'fozzie' do
   database_name 'databass'
   password 'wokkawokka'
   host 'mars'
-  privileges [:select, :update, :insert]
+  privileges %w(SELECT UPDATE INSERT)
   require_ssl true
   ctrl_password 'gsql'
   action :grant
@@ -135,7 +135,7 @@ mariadb_user 'moozie' do
   password hash2
   ctrl_password 'gsql'
   host '127.0.0.1'
-  privileges [:select, :update, :insert]
+  privileges %w(SELECT UPDATE INSERT)
   require_ssl false
   action :grant
 end
@@ -147,7 +147,7 @@ mariadb_user 'rizzo' do
   password 'salmon'
   ctrl_password 'gsql'
   host '127.0.0.1'
-  privileges [:select]
+  privileges ['SELECT']
   require_ssl false
   action :grant
 end

--- a/test/integration/resources/controls/user_spec.rb
+++ b/test/integration/resources/controls/user_spec.rb
@@ -38,4 +38,12 @@ control 'mariadb_user' do
   describe sql.query('show grants for \'rizzo\'@\'127.0.0.1\'') do
     its(:stdout) { should include '*125EA03B506F7C876D9321E9055F37601461E970' }
   end
+
+  describe sql.query("SELECT Select_priv, Insert_priv, Update_priv FROM mysql.db WHERE Host='mars' AND User='foozie' AND Db = 'databass'") do
+    its('stdout') { should_not match 'N' }
+  end
+
+  describe sql.query("SELECT Select_priv FROM mysql.db WHERE Host='mars' AND User='foozie' AND Db = 'datasalmon'") do
+    its('stdout') { should_not match 'N' }
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/sous-chefs/mariadb/issues/243

Rationale :
MariaDB doesn't allow granting privileges containing an
undersocre :
   ```sql
  MariaDB [(none)]> GRANT select ON *.* TO 'root'@'localhost';
  Query OK, 0 rows affected (0.00 sec)

  MariaDB [(none)]> GRANT show_view ON *.* TO 'root'@'localhost';
  ERROR 1064 (42000): You have an error in your SQL syntax; check the
  manual that corresponds to your MariaDB server version for the right
  syntax to use near 'ON *.* TO 'root'@'localhost'' at line 1
   ```