### PR TITLE
Change apt_repository property, because it conflicts with apt resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - Write a new documentation following sous-chefs.org guidelines
 - undefined method `ext_conf_dir` when using mariadb 2.0.0 ([#225](https://github.com/sous-chefs/mariadb/issues/225)) 
+- Rename property `apt_repository` to `apt_repository_uri` in repository resource ([#245](https://github.com/sous-chefs/mariadb/issues/245))
 
 ### Removed
 

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -22,7 +22,7 @@ property :yum_gpg_key_uri,    String, default: 'https://yum.mariadb.org/RPM-GPG-
 property :apt_gpg_keyserver,  String, default: 'keyserver.ubuntu.com'
 property :apt_gpg_key,        String, default: 'F1656F24C74CD1D8'
 property :apt_key_proxy,      [String, false], default: false
-property :apt_repository,     String, default: 'http://mariadb.mirrors.ovh.net/MariaDB/repo'
+property :apt_repository_uri, String, default: 'http://mariadb.mirrors.ovh.net/MariaDB/repo'
 
 action :add do
   case node['platform_family']
@@ -48,7 +48,7 @@ action :add do
     apt_key = new_resource.apt_gpg_key == 'F1656F24C74CD1D8' && node['platform'] == 'debian' && node['platform_version'].split('.')[0].to_i < 9 ? 'CBCB082A1BB943DB' : new_resource.apt_gpg_key
 
     apt_repository 'mariadb_org_repository' do
-      uri          "#{new_resource.apt_repository}/#{new_resource.version}/#{node['platform']}"
+      uri          "#{new_resource.apt_repository_uri}/#{new_resource.version}/#{node['platform']}"
       components   ['main']
       distribution node['lsb']['codename']
       keyserver new_resource.apt_gpg_keyserver


### PR DESCRIPTION
## Description

It correct the repository install for Chef 13

### Issues Resolved

Resolve issue [#245]

### Check List
- [X] All tests pass. See https://github.com/sous-chefs/apache2/blob/master/TESTING.md
- [O] New functionality includes testing. (as it's mainly for chef 13 support, no tests added)
- [N/A] New functionality has been documented in the README if applicable