### PR TITLE
## [3.1.1] (2019-11-16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [3.1.1] (2019-11-16)
+
+### Added
+
+- Added ability to specify package names for server and client (only) during install.
+
+### Fixed
+
+- Fixed support statement for chef-13 in metadata, rejected since 2.0.0
+
 ## [3.1.0] (2019-10-24)
 
 ### Fixed

--- a/documentation/resource_mariadb_client_install.md
+++ b/documentation/resource_mariadb_client_install.md
@@ -11,6 +11,7 @@ This resource installs mariadb client packages.
 Name                | Types             | Description                                                   | Default                                   | Required?
 ------------------- | ----------------- | ------------------------------------------------------------- | ----------------------------------------- | ---------
 `version`           | String            | Version of MariaDB to install                                 | `10.3`                                    | no
+`package_name`      | String            | Name of MariaDB client package to install                            | `MariaDB-client`                   | no
 `setup_repo`        | Boolean           | Define if you want to add the MariaDB repository              | `true`                                    | no
 
 ### Examples

--- a/documentation/resource_mariadb_server_install.md
+++ b/documentation/resource_mariadb_server_install.md
@@ -12,6 +12,7 @@ This resource installs mariadb server packages.
 Name                            | Types             | Description                                                   | Default                                   | Required?
 ------------------------------- | ----------------- | ------------------------------------------------------------- | ----------------------------------------- | ---------
 `version`                       | String            | Version of MariaDB to install                                 | `10.3`                                    | no
+`package_name`                  | String            | Name of MariaDB server package to install                     | `MariaDB-server`                          | no
 `setup_repo`                    | Boolean           | Define if you want to add the MariaDB repository              | `true`                                    | no
 `mycnf_file`                    | String            |                                                               | `"#{conf_dir}/my.cnf"` (1)                | no
 `extra_configuration_directory` | String            |                                                               | `ext_conf_dir` (2)                        | no

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -224,11 +224,6 @@ module MariaDBCookbook
       end
     end
 
-    # determine the platform specific server package name
-    def server_pkg_name
-      platform_family?('debian') ? "mariadb-server-#{new_resource.version}" : 'MariaDB-server'
-    end
-
     # given the base URL build the complete URL string for a yum repo
     def yum_repo_url(base_url)
       "#{base_url}/#{new_resource.version}/#{yum_repo_platform_string}"

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,8 +6,8 @@ description      'Installs/Configures MariaDB'
 
 source_url       'https://github.com/sous-chefs/mariadb'
 issues_url       'https://github.com/sous-chefs/mariadb/issues'
-chef_version     '>= 13'
-version          '3.1.0'
+chef_version     '>= 14'
+version          '3.1.1'
 
 supports 'ubuntu'
 supports 'debian', '>= 9.0'

--- a/resources/client_install.rb
+++ b/resources/client_install.rb
@@ -18,8 +18,12 @@
 
 property :version,    String, default: '10.3'
 property :setup_repo, [true, false], default: true
+property :package_name, String, default: 'MariaDB-client'
 
 action :install do
+  node.run_state['mariadb'] ||= {}
+  node.run_state['mariadb']['client_pkg'] = new_resource.package_name
+
   mariadb_repository 'Add mariadb.org repository' do
     version new_resource.version
     only_if { new_resource.setup_repo }
@@ -29,6 +33,6 @@ action :install do
   when 'debian'
     package "mariadb-client-#{new_resource.version}"
   when 'rhel', 'fedora', 'amazon'
-    package 'MariaDB-client'
+    package new_resource.package_name
   end
 end

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -27,7 +27,7 @@ property :external_pid_file, String,        default: lazy { "/var/run/mysql/#{ve
 property :password,          [String, nil], default: 'generate'
 property :port,              Integer,       default: 3306
 property :initdb_locale,     String,        default: 'UTF-8'
-property :package_name,	     String,        default: node['platform_family'] == 'debian' ? "mariadb-server-#{new_resource.version}" : 'MariaDB-server'
+property :package_name,      String,        default: node['platform_family'] == 'debian' ? "mariadb-server-#{new_resource.version}" : 'MariaDB-server'
 
 action :install do
   node.run_state['mariadb'] ||= {}

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -27,17 +27,20 @@ property :external_pid_file, String,        default: lazy { "/var/run/mysql/#{ve
 property :password,          [String, nil], default: 'generate'
 property :port,              Integer,       default: 3306
 property :initdb_locale,     String,        default: 'UTF-8'
+property :package_name,	     String,        default: node['platform_family'] == 'debian' ? "mariadb-server-#{new_resource.version}" : 'MariaDB-server'
 
 action :install do
   node.run_state['mariadb'] ||= {}
   node.run_state['mariadb']['version'] = new_resource.version
 
+  # this should be removed. It's cute but costly.
   mariadb_client_install 'Install MariaDB Client' do
     version new_resource.version
     setup_repo new_resource.setup_repo
+    package_name node.run_state['mariadb']['client_pkg'] if node.run_state['mariadb'] && node.run_state['mariadb']['client_pkg'] 
   end
 
-  package server_pkg_name
+  package new_resource.package_name
 end
 
 action :create do

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -37,7 +37,7 @@ action :install do
   mariadb_client_install 'Install MariaDB Client' do
     version new_resource.version
     setup_repo new_resource.setup_repo
-    package_name node.run_state['mariadb']['client_pkg'] if node.run_state['mariadb'] && node.run_state['mariadb']['client_pkg'] 
+    package_name node.run_state['mariadb']['client_pkg'] if node.run_state['mariadb'] && node.run_state['mariadb']['client_pkg']
   end
 
   package new_resource.package_name


### PR DESCRIPTION
### Added

- Added ability to specify package names for server and client (only) during install.

### Fixed

- Fixed support statement for chef-13 in metadata, rejected since 2.0.0

## Description

This change scratches an itch and allows - when setup_repo [sic] set false and the package_name set to the distro name - the machine to be set up with the standard mariadb package instead of the vendor-custom package.

Why do this?  I'd like to manage the config programmatically without deviating from the distro-supported/tested binaries.

### Issues 

This PR doesn't include testing.  I'm not sure what I should be testing.  This will need your help if you want that part.

The bit in helpers and the install_action for mariadb is a bit of a concern, but I didn't make anythign better with my change.  Please adjust as appropriate.

### Notes

This PR is public-domain.  It's submitted back to the parent project in the hopes of being valuable and eventually maintainable.

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/mariadb/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
