### PR TITLE
Fixed Case Sensitive Match

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -221,7 +221,7 @@ module MariaDBCookbook
 
     # determine the platform specific server package name
     def server_pkg_name
-      platform_family?('debian') ? "mariadb-server-#{new_resource.version}" : 'MariaDB-server'
+      platform_family?('debian') ? "mariadb-server-#{new_resource.version}" : 'mariadb-server'
     end
 
     # given the base URL build the complete URL string for a yum repo


### PR DESCRIPTION
## Description

Installs Maria DB on non debian systems such as Centos 8.

### Issues Resolved

Will now match non Debian due to case sensitive package finders such as Yum.

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/mariadb/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
