### PR TITLE
Centos 8 yum repo fix

### DIFF
--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -50,6 +50,12 @@ platforms:
       platform: rhel
       pid_one_command: /usr/lib/systemd/systemd
 
+  - name: centos-8
+    driver:
+      image: dokken/centos-8
+      platform: rhel
+      pid_one_command: /usr/lib/systemd/systemd
+
   - name: ubuntu-16.04
     driver:
       image: dokken/ubuntu-16.04

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -16,6 +16,7 @@ verifier:
 platforms:
   - name: centos-6
   - name: centos-7
+  - name: centos-8
   - name: debian-9
   - name: ubuntu-16.04
   - name: ubuntu-18.04

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -40,11 +40,19 @@ action :add do
       source new_resource.yum_gpg_key_uri
     end
 
+    # yum repository workaround for CentOS 8 and RHEL 8
+    # https://jira.mariadb.org/browse/MDEV-20673
+    opts = {}
+    if platform_family?('rhel') && node['platform_version'].to_f >= 8
+      opts[:module_hotfixes] = 1
+    end
+
     yum_repository "MariaDB #{new_resource.version}" do
       repositoryid "mariadb#{new_resource.version}"
       description "MariaDB.org #{new_resource.version}"
       baseurl     yum_repo_url('http://yum.mariadb.org')
       enabled     new_resource.enable_mariadb_org
+      options     opts
       gpgcheck    true
       gpgkey      "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-MariaDB-#{new_resource.version}"
     end


### PR DESCRIPTION
## Description

Adds tests for CentOS 8.

Fixes yum repo configuration on CentOS/RHEL 8, without these fixes DNF does not seem to be able to find the MariaDB-server package from mariadb.org yum repositories. Mariadb.org Jira ticket with more information ([MDEV-20673](https://jira.mariadb.org/browse/MDEV-20673))

### Issues Resolved

#300 

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/mariadb/blob/master/TESTING.md
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
