### PR TITLE
Fix default libgalera_smm.so path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## 4.1.1 (2020-11-18)
 
+- fix default `libgalera_smm.so` path on x86\_64 systems
 - resolved cookstyle error: spec/libraries/helper_spec.rb:2:18 convention: `Style/RedundantFileExtensionInRequire`
 - resolved underscore bug: `mariadb_user`'s `:grant` action incorrectly handled privileges with underscores, now it correctly substitutes them with a space
 

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -257,5 +257,9 @@ module MariaDBCookbook
         '/var/run/mysqld/mysqld.pid'
       end
     end
+
+    def default_libgalera_smm_path
+      node['kernel']['machine'] == 'x86_64' ? '/usr/lib64/galera/libgalera_smm.so' : '/usr/lib/galera/libgalera_smm.so'
+    end
   end
 end

--- a/resources/galera_configuration.rb
+++ b/resources/galera_configuration.rb
@@ -27,7 +27,7 @@ property :gcomm_address,                         [String, nil]
 property :server_id,                             Integer,        default: 100
 property :wsrep_sst_method,                      String,         default: 'rsync'
 property :wsrep_sst_auth,                        String,         default: 'sstuser:some_secret_password'
-property :wsrep_provider,                        String,         default: '/usr/lib/galera/libgalera_smm.so'
+property :wsrep_provider,                        String,         default: lazy { default_libgalera_smm_path }
 property :wsrep_slave_threads,                   String,         default: '%{auto}'
 property :innodb_flush_log_at_trx_commit,        Integer,        default: 2
 property :wsrep_node_address_interface,          [String, nil]

--- a/test/integration/galera_configuration/controls/galera_spec.rb
+++ b/test/integration/galera_configuration/controls/galera_spec.rb
@@ -38,7 +38,7 @@ control 'mariadb_galera_configuration' do
     wsrep_cluster_name = galera_cluster
     wsrep_sst_method = mariabackup
     wsrep_sst_auth = sstuser:some_secret_password
-    wsrep_provider = /usr/lib/galera/libgalera_smm.so
+    wsrep_provider = /usr/lib64/galera/libgalera_smm.so
     wsrep_slave_threads = 8
     wsrep_node_address = #{ip_address}
   EOF


### PR DESCRIPTION
On x86_64 systems the library is located under `/usr/lib64` and not `/usr/lib`.