### PR TITLE
Fix user grants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 - resolved cookstyle error: spec/libraries/helper_spec.rb:2:18 convention: `Style/RedundantFileExtensionInRequire`
+- resolved underscore bug: `mariadb_user`'s `:grant` action incorrectly handled privileges with underscores, now it correctly substitutes them with a space
 
 ## 4.1.0 (2020-08-27)
 

--- a/documentation/resource_mariadb_user.md
+++ b/documentation/resource_mariadb_user.md
@@ -29,30 +29,40 @@ Name              | Types                  | Description                        
 
 ## Examples
 
+Create an user but grant no privileges:
+
 ```ruby
-# Create an user but grant no privileges
 mariadb_user 'disenfranchised' do
   password 'super_secret'
   action :create
 end
+```
 
-# Create an user using a hashed password string instead of plain text one
+Create an user using a hashed password string instead of plain text one:
+
+```ruby
 mariadb_user 'disenfranchised' do
   password hashed_password('md5eacdbf8d9847a76978bd515fae200a2a')
   action :create
 end
+```
 
-# Drop a user
+Drop a user:
+
+```ruby
 mariadb_user 'foo_user' do
   action :drop
 end
+```
 
-# Grant SELECT, UPDATE, and INSERT privileges to all tables in foo db from all hosts
+Grant `SELECT`, `UPDATE`, and `INSERT` privileges to all tables in foo db from all hosts:
+
+```ruby
 mariadb_user 'foo_user' do
   password 'super_secret'
   database_name 'foo'
   host '%'
-  privileges [:select,:update,:insert]
+  privileges [:select, :update, :insert]
   action :grant
 end
 ```

--- a/documentation/resource_mariadb_user.md
+++ b/documentation/resource_mariadb_user.md
@@ -66,3 +66,15 @@ mariadb_user 'foo_user' do
   action :grant
 end
 ```
+
+Use underscores when specifying grants that use spaces:
+
+```ruby
+mariadb_user 'foo_user' do
+  password 'super_secret'
+  database_name 'foo'
+  host '%'
+  privileges [:reload, :process, :lock_tables, :replication_client]
+  action :grant
+end
+```

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -245,7 +245,7 @@ action :grant do
   # Repair
   if incorrect_privs
     converge_by "Granting privs for '#{new_resource.username}'@'#{new_resource.host}'" do
-      repair_sql = "GRANT #{new_resource.privileges.join(',')}"
+      repair_sql = "GRANT #{new_resource.privileges.map(&:upcase).join(', ').gsub(/_/, ' ')}"
       repair_sql << " ON #{db_name}.#{tbl_name}"
       repair_sql << " TO '#{new_resource.username}'@'#{new_resource.host}' IDENTIFIED BY"
       repair_sql << if new_resource.password.is_a?(HashedPassword)

--- a/test/cookbooks/test/recipes/user_database.rb
+++ b/test/cookbooks/test/recipes/user_database.rb
@@ -152,6 +152,14 @@ mariadb_user 'rizzo' do
   action :grant
 end
 
+mariadb_user 'spaces' do
+  password 'nounderscore'
+  ctrl_password 'gsql'
+  host '127.0.0.1'
+  privileges [:lock_tables, :replication_client]
+  action :grant
+end
+
 mariadb_database 'flush privileges' do
   database_name 'databass'
   password 'gsql'

--- a/test/integration/resources/controls/user_spec.rb
+++ b/test/integration/resources/controls/user_spec.rb
@@ -11,6 +11,7 @@ control 'mariadb_user' do
 
   describe sql.query("show grants for 'fozzie'@'mars'") do
     its('output') { should include '*EF112B3D562CB63EA3275593C10501B59C4A390D' }
+    its('output') { should include 'GRANT SELECT, INSERT, UPDATE ON `databass`.* TO `fozzie`@`mars`' }
   end
 
   describe sql.query('show grants for  \'moozie\'@\'127.0.0.1\'') do
@@ -38,5 +39,9 @@ control 'mariadb_user' do
 
   describe sql.query('show grants for \'rizzo\'@\'127.0.0.1\'') do
     its('output') { should include '*125EA03B506F7C876D9321E9055F37601461E970' }
+  end
+
+  describe sql.query("show grants for 'spaces'@'127.0.0.1'") do
+    its('output') { should include 'GRANT LOCK TABLES, REPLICATION CLIENT ON *.* TO `spaces`@`127.0.0.1`' }
   end
 end


### PR DESCRIPTION
Currently this cookbook returns an error when trying to set grants that have spaces as the underscore was not replaced with a space:

```
FATAL: ERROR 1064 (42000) at line 1: You have an error in your SQL syntax; check the manual that corresponds to your MariaDB server version for the right syntax to use near 'lock_tables,replication_client ON *.* TO 'sstuser'@'localhost' IDENTIFIED BY ...' at line 1
```

This PR fixes that (and up cases the grant names).