### PR TITLE
Add ability to bootstrap Galera cluster using galera_new_cluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Add `bootstrap` and `join` actions to `mariadb_galera_configuration` to bootstrap and join clusters
+
 ## 4.1.4 - *2020-11-26*
 
 - Add back `selinux_policy` to install vendored SELinux policies

--- a/documentation/resource_mariadb_galera_configuration.md
+++ b/documentation/resource_mariadb_galera_configuration.md
@@ -11,24 +11,24 @@ Do all configuration to have a working Galera Cluster
 
 Name                                   | Types             | Description                                                   | Default                                   | Required?
 ---------------------------------------| ----------------- | ------------------------------------------------------------- | ----------------------------------------- | ---------
-`version`                              | String            | Version of MariaDB installed                                  | `10.3`                                    | no
+`cluster_name`                         | String            |                                                               | `galera_cluster`                          | no
+`cluster_nodes`                        ï Array             |                                                               | `[]`                                      | no
+`cluster_search_query`                 | String, NilClass  |                                                               | `nil`                                     | no
 `cookbook`                             | String            |                                                               | `mariadb`                                 | no
 `extra_configuration_directory`        | String            |                                                               | `ext_conf_dir` (1)                        | no
-`cluster_name`                         | String            |                                                               | `galera_cluster`                          | no
-`cluster_search_query`                 | String, NilClass  |                                                               | `nil`                                     | no
 `gcomm_address`                        | String            |                                                               | `nil`                                     | no
+`innodb_flush_log_at_trx_commit`       | Integer           |                                                               | `2`                                       | no
+`options`                              | Hash              |                                                               | `{}`                                      | no
 `server_id`                            | Integer           |                                                               | `100`                                     | no
-`wsrep_sst_method`                     | String            | Can be 'rsync', 'xtrabackup' or 'mariabackup'                 | `rsync`                                   | no
-`wsrep_sst_auth`                       | String            |                                                               | `sstuser:some_secret_password`            | no
+`version`                              | String            | Version of MariaDB installed                                  | `10.3`                                    | no
+`wsrep_node_address_interface`         | String, NilClass  |                                                               | `nil`                                     | no
+`wsrep_node_incoming_address_interface`| String, NilClass  |                                                               | `nil`                                     | no
+`wsrep_node_port`                      | Integer, NilClass |                                                               | `nil`                                     | no
+`wsrep_provider_options`               | Hash              |                                                               | `{'gcache.size': '512M'}`                 | no
 `wsrep_provider`                       | String            |                                                               | `/usr/lib/galera/libgalera_smm.so`        | no
 `wsrep_slave_threads`                  | String            | By default the MariaDB recommended value is set (nb_cpu * 4)  | `%{auto}`                                 | no
-`innodb_flush_log_at_trx_commit`       | Integer           |                                                               | `2`                                       | no
-`wsrep_node_address_interface`         | String, NilClass  |                                                               | `nil`                                     | no
-`wsrep_node_port`                      | Integer, NilClass |                                                               | `nil`                                     | no
-`wsrep_node_incoming_address_interface`| String, NilClass  |                                                               | `nil`                                     | no
-`wsrep_provider_options`               | Hash              |                                                               | `{'gcache.size': '512M'}`                 | no
-`options`                              | Hash              |                                                               | `{}`                                      | no
-`cluster_nodes`                        ï Array             |                                                               | `[]`                                      | no
+`wsrep_sst_auth`                       | String            |                                                               | `sstuser:some_secret_password`            | no
+`wsrep_sst_method`                     | String            | Can be 'rsync', 'xtrabackup' or 'mariabackup'                 | `rsync`                                   | no
 
 (1) `ext_conf_dir` is a helper method which return the extra configuration directory based on OS flavor
 
@@ -37,7 +37,7 @@ Name                                   | Types             | Description        
 If you use a chef-server, set an attribute within your cookbook to determine which nodes belong to the cluster. If your cookbook is 'mycookbook' set:
 
 ```ruby
-default['mycookbook']['galera']['cluster_name'] = 'my_functionnal_cluster_name'
+default['mycookbook']['galera']['cluster_name'] = 'my_cluster_name'
 ```
 
 Then all nodes to add to gcomm will be choosen with a search based on this attribute:
@@ -45,8 +45,8 @@ Then all nodes to add to gcomm will be choosen with a search based on this attri
 ```ruby
 mariadb_galera_configuration 'MariaDB Galera Server Configuration' do
   version '10.3'
-  cluster_name 'my_functionnal_cluster_name'
-  cluster_search_query "mycookbook_galera_cluster_name:my_functionnal_cluster_name"
+  cluster_name 'my_cluster_name'
+  cluster_search_query "mycookbook_galera_cluster_name:my_cluster_name"
 end
 ```
 
@@ -55,7 +55,7 @@ If you don't want to have a dynamic node galera node management, set manually th
 ```ruby
 mariadb_galera_configuration 'MariaDB Galera Server Configuration' do
   version '10.3'
-  cluster_name 'my_functionnal_cluster_name'
+  cluster_name 'my_cluster_name'
   gcomm_address 'gcomm://node1.fqdn,node2.fqdn'
 end
 ```

--- a/documentation/resource_mariadb_galera_configuration.md
+++ b/documentation/resource_mariadb_galera_configuration.md
@@ -1,18 +1,20 @@
 # mariadb_galera_configuration
 
-Do all configuration to have a working Galera Cluster
+Do all configuration to have a working Galera Cluster.
 
 ## Actions
 
-- `create` - (default) Create & Maintain the configuration file
-- `remove` - Remove the galera configuration file
+- `create` - (default) creates and maintains the Galera configuration file
+- `bootstrap` - bootstraps a new Galera cluster
+- `join` - joins an existing Galera cluster
+- `remove` - removes the galera configuration file
 
 ## Properties
 
 Name                                   | Types             | Description                                                   | Default                                   | Required?
----------------------------------------| ----------------- | ------------------------------------------------------------- | ----------------------------------------- | ---------
+-------------------------------------- | ----------------- | ------------------------------------------------------------- | ----------------------------------------- | ---------
 `cluster_name`                         | String            |                                                               | `galera_cluster`                          | no
-`cluster_nodes`                        ï Array             |                                                               | `[]`                                      | no
+`cluster_nodes`                        | Array             |                                                               | `[]`                                      | no
 `cluster_search_query`                 | String, NilClass  |                                                               | `nil`                                     | no
 `cookbook`                             | String            |                                                               | `mariadb`                                 | no
 `extra_configuration_directory`        | String            |                                                               | `ext_conf_dir` (1)                        | no
@@ -30,17 +32,21 @@ Name                                   | Types             | Description        
 `wsrep_sst_auth`                       | String            |                                                               | `sstuser:some_secret_password`            | no
 `wsrep_sst_method`                     | String            | Can be 'rsync', 'xtrabackup' or 'mariabackup'                 | `rsync`                                   | no
 
-(1) `ext_conf_dir` is a helper method which return the extra configuration directory based on OS flavor
+1. `ext_conf_dir` is a helper method which return the extra configuration directory based on OS flavor.
 
 ## Examples
 
-If you use a chef-server, set an attribute within your cookbook to determine which nodes belong to the cluster. If your cookbook is 'mycookbook' set:
+### Managing the Galera Cluster address (`gcomm://`)
+
+These examples show how to set the cluster address in the config file by either using a Chef search or providing a static value. Note that this example will not result in a bootstrap cluster.
+
+If you use a Chef server, set an attribute within your cookbook to determine which nodes belong to the cluster. If your cookbook is 'mycookbook' set:
 
 ```ruby
 default['mycookbook']['galera']['cluster_name'] = 'my_cluster_name'
 ```
 
-Then all nodes to add to gcomm will be choosen with a search based on this attribute:
+Then use a Chef search to find other nodes and add these hosts to the gcomm address:
 
 ```ruby
 mariadb_galera_configuration 'MariaDB Galera Server Configuration' do
@@ -50,7 +56,7 @@ mariadb_galera_configuration 'MariaDB Galera Server Configuration' do
 end
 ```
 
-If you don't want to have a dynamic node galera node management, set manually the gcomm_address with all nodes you want in it:
+If you don't want to have a dynamic node galera node management, you can manually the gcomm address:
 
 ```ruby
 mariadb_galera_configuration 'MariaDB Galera Server Configuration' do
@@ -59,3 +65,31 @@ mariadb_galera_configuration 'MariaDB Galera Server Configuration' do
   gcomm_address 'gcomm://node1.fqdn,node2.fqdn'
 end
 ```
+
+### Bootstrapping a new cluster and joining additional nodes
+
+Out the box, MariaDB does not bootstrap a Galera cluster. In addition to bootstrapping the cluster, Chef will also set a `node['mariadb']['galera']['bootstrapped']` attribute with a `true` value so that you can search for nodes that have successfully joined a cluster.
+
+Following on from the previous example, to do this you should specific the `:bootstrap` action:
+
+```
+mariadb_galera_configuration 'MariaDB Galera Server Configuration' do
+  version '10.3'
+  cluster_name 'my_cluster_name'
+  cluster_search_query "mycookbook_galera_cluster_name:my_cluster_name AND mariadb_galera_bootstrapped:true"
+  action [:create, :bootstrap]
+end
+```
+
+This should only be done by one node in cluster you're going to create, other nodes will want to use the `:join` action to join the cluster:
+
+```
+mariadb_galera_configuration 'MariaDB Galera Server Configuration' do
+  version '10.3'
+  cluster_name 'my_cluster_name'
+  cluster_search_query "mycookbook_galera_cluster_name:my_cluster_name AND mariadb_galera_bootstrapped:true"
+  action [:create, :join]
+end
+```
+
+Now any joiner nodes will attempt to join the bootstap node each time Chef runs until it is successful.

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -259,7 +259,12 @@ module MariaDBCookbook
     end
 
     def default_libgalera_smm_path
-      node['kernel']['machine'] == 'x86_64' ? '/usr/lib64/galera/libgalera_smm.so' : '/usr/lib/galera/libgalera_smm.so'
+      case node['platform_family']
+      when 'rhel', 'fedora', 'amazon'
+        '/usr/lib64/galera/libgalera_smm.so'
+      when 'debian'
+        '/usr/lib/galera/libgalera_smm.so'
+      end
     end
 
     def mariadb_status_value(variable)

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -261,5 +261,23 @@ module MariaDBCookbook
     def default_libgalera_smm_path
       node['kernel']['machine'] == 'x86_64' ? '/usr/lib64/galera/libgalera_smm.so' : '/usr/lib/galera/libgalera_smm.so'
     end
+
+    def mariadb_status_value(variable)
+      query = "select VARIABLE_VALUE from information_schema.GLOBAL_STATUS where VARIABLE_NAME = \"#{variable}\";"
+      result = shell_out!("mysql -B -N -uroot -p#{node.run_state['mariadb_root_password']} -e '#{query}'")
+      result.stdout.chomp
+    end
+
+    def galera_cluster_bootstrapped?
+      mariadb_status_value('wsrep_ready') == 'ON'
+    rescue Mixlib::ShellOut::ShellCommandFailed
+      false
+    end
+
+    def galera_cluster_joined?
+      mariadb_status_value('wsrep_cluster_size').to_i > 1
+    rescue Mixlib::ShellOut::ShellCommandFailed
+      false
+    end
   end
 end

--- a/resources/galera_configuration.rb
+++ b/resources/galera_configuration.rb
@@ -18,24 +18,25 @@ provides :mariadb_galera_configuration
 
 include MariaDBCookbook::Helpers
 
-property :version,                               String,         default: '10.3'
+property :bootstrap_cluster,                     [true, false],  default: false
+property :cluster_name,                          String,         default: 'galera_cluster'
+property :cluster_nodes,                         Array,          default: []
+property :cluster_search_query,                  [String, nil]
 property :cookbook,                              String,         default: 'mariadb'
 property :extra_configuration_directory,         String,         default: lazy { ext_conf_dir }
-property :cluster_name,                          String,         default: 'galera_cluster'
-property :cluster_search_query,                  [String, nil]
 property :gcomm_address,                         [String, nil]
-property :server_id,                             Integer,        default: 100
-property :wsrep_sst_method,                      String,         default: 'rsync'
-property :wsrep_sst_auth,                        String,         default: 'sstuser:some_secret_password'
-property :wsrep_provider,                        String,         default: lazy { default_libgalera_smm_path }
-property :wsrep_slave_threads,                   String,         default: '%{auto}'
 property :innodb_flush_log_at_trx_commit,        Integer,        default: 2
-property :wsrep_node_address_interface,          [String, nil]
-property :wsrep_node_port,                       [Integer, nil], default: nil
-property :wsrep_node_incoming_address_interface, String
-property :wsrep_provider_options,                Hash,           default: { 'gcache.size': '512M' }
 property :options,                               Hash,           default: {}
-property :cluster_nodes,                         Array,          default: []
+property :server_id,                             Integer,        default: 100
+property :version,                               String,         default: '10.3'
+property :wsrep_node_address_interface,          [String, nil]
+property :wsrep_node_incoming_address_interface, String
+property :wsrep_node_port,                       [Integer, nil], default: nil
+property :wsrep_provider,                        String,         default: lazy { default_libgalera_smm_path }
+property :wsrep_provider_options,                Hash,           default: { 'gcache.size': '512M' }
+property :wsrep_slave_threads,                   String,         default: '%{auto}'
+property :wsrep_sst_auth,                        String,         default: 'sstuser:some_secret_password'
+property :wsrep_sst_method,                      String,         default: 'rsync'
 
 action :create do
   case new_resource.wsrep_sst_method

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -62,6 +62,10 @@ action :create do
 
   # Here we make sure to escape all \ ' and " characters so that they will be preserved in the final password
   mariadb_root_password = mariadb_root_password.gsub('\\', '\\\\\\').gsub('\'', '\\\\\'').gsub('"', '\\\\"')
+
+  # Store the password in the run state for any other resources that may need it.
+  node.run_state['mariadb_root_password'] = mariadb_root_password
+
   # Generate a random password or set a password defined with node['mariadb']['server_root_password'].
   # The password is set or change at each run. It is good for security if you choose to set a random password and
   # allow you to change the root password if needed.

--- a/test/cookbooks/test/metadata.rb
+++ b/test/cookbooks/test/metadata.rb
@@ -7,3 +7,4 @@ description 'Installs/Configures test'
 version '0.1.0'
 
 depends 'mariadb'
+depends 'selinux'

--- a/test/cookbooks/test/recipes/galera_configuration.rb
+++ b/test/cookbooks/test/recipes/galera_configuration.rb
@@ -13,4 +13,5 @@ end
 mariadb_galera_configuration 'MariaDB Galera Configuration' do
   version '10.3'
   wsrep_sst_method 'mariabackup'
+  action [:create, :bootstrap]
 end

--- a/test/cookbooks/test/recipes/server_install.rb
+++ b/test/cookbooks/test/recipes/server_install.rb
@@ -1,3 +1,9 @@
+if platform_family?('rhel')
+  package 'libselinux-utils'
+  selinux_state 'enforcing'
+  selinux_policy_install 'install'
+end
+
 mariadb_repository 'install'
 
 mariadb_server_install 'package' do

--- a/test/integration/galera_configuration/controls/galera_spec.rb
+++ b/test/integration/galera_configuration/controls/galera_spec.rb
@@ -46,4 +46,15 @@ control 'mariadb_galera_configuration' do
   describe file(galera_config_file) do
     its('content') { should eq content }
   end
+
+  describe mysql_session('root', 'gsql').query('show status like "wsrep_%";') do
+    {
+      'wsrep_cluster_size' => '1',
+      'wsrep_cluster_status' => 'Primary',
+      'wsrep_evs_state' => 'OPERATIONAL',
+      'wsrep_ready' => 'ON',
+    }.each_pair do |k, v|
+      its('output') { should match(/^#{k}\s*#{v}$/) }
+    end
+  end
 end

--- a/test/integration/galera_configuration/controls/galera_spec.rb
+++ b/test/integration/galera_configuration/controls/galera_spec.rb
@@ -1,5 +1,10 @@
-include_dir = '/etc/mysql/conf.d'
-include_dir = '/etc/my.cnf.d' if os.family == 'redhat'
+if os.redhat?
+  include_dir = '/etc/my.cnf.d'
+  libgalera_smm_path = '/usr/lib64/galera/libgalera_smm.so'
+else
+  include_dir = '/etc/mysql/conf.d'
+  libgalera_smm_path = '/usr/lib/galera/libgalera_smm.so'
+end
 
 galera_config_file = "#{include_dir}/90-galera.cnf"
 ip_address = sys_info.ip_address.strip
@@ -38,7 +43,7 @@ control 'mariadb_galera_configuration' do
     wsrep_cluster_name = galera_cluster
     wsrep_sst_method = mariabackup
     wsrep_sst_auth = sstuser:some_secret_password
-    wsrep_provider = /usr/lib64/galera/libgalera_smm.so
+    wsrep_provider = #{libgalera_smm_path}
     wsrep_slave_threads = 8
     wsrep_node_address = #{ip_address}
   EOF


### PR DESCRIPTION
A Galera cluster needs to be bootstrapped and is not done by default. This PR adds the option to run `galera_new_cluster` on a node so that other potential cluster members can connect to it.
