### PR TITLE
Remove unused selinux_policy dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+- Remove unused `selinux_policy` cookbook dependency
+
 ## 4.1.2 (2020-11-18)
 
 - fix default `libgalera_smm.so` path on x86\_64 systems

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,5 +11,3 @@ version          '4.1.2'
 supports 'ubuntu', '>= 18.04'
 supports 'debian', '>= 9.0'
 supports 'centos', '>= 7.0'
-
-depends 'selinux_policy', '~> 2.0'


### PR DESCRIPTION
The `selinux_policy` cookbook is not used in this cookbook and can be removed.
