### PR TITLE
Install SELinux policies if they exist and SELinux is available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Add back `selinux_policy` to install vendored SELinux policies
+
 ## 4.1.3 - *2020-11-23*
 
 - Remove unused `selinux_policy` cookbook dependency

--- a/metadata.rb
+++ b/metadata.rb
@@ -11,3 +11,5 @@ version          '4.1.3'
 supports 'ubuntu', '>= 18.04'
 supports 'debian', '>= 9.0'
 supports 'centos', '>= 7.0'
+
+depends 'selinux_policy', '~> 2.4'

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -39,6 +39,13 @@ action :install do
   end
 
   package server_pkg_name
+
+  %w(mariadb-server mariadb).each do |m|
+    selinux_policy_module m do
+      content lazy { ::File.read("/usr/share/mysql/policy/selinux/#{m}.te") }
+      only_if { selinux_enabled? }
+    end
+  end
 end
 
 action :create do
@@ -99,4 +106,6 @@ end
 
 action_class do
   include MariaDBCookbook::Helpers
+
+  Chef::Resource.include Chef::Util::Selinux
 end


### PR DESCRIPTION
The RPM installs vendored SELinux policies but they are not installed. This PR adds back the `selinux_policy` cookbook dependency and installs these policies if SELinux is enabled on the system.