### PR TITLE
Ensure we run selinux_policy_install if selinux is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Ensure we run `selinux_policy_install` if selinux is enabled
+
 ## 4.2.0 - *2020-12-01*
 
 - Add `bootstrap` and `join` actions to `mariadb_galera_configuration` to bootstrap and join clusters

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -40,6 +40,8 @@ action :install do
 
   package server_pkg_name
 
+  selinux_policy_install 'mariadb' if selinux_enabled?
+
   %w(mariadb-server mariadb).each do |m|
     selinux_policy_module m do
       content lazy { ::File.read("/usr/share/mysql/policy/selinux/#{m}.te") }
@@ -110,6 +112,5 @@ end
 
 action_class do
   include MariaDBCookbook::Helpers
-
-  Chef::Resource.include Chef::Util::Selinux
+  include Chef::Util::Selinux
 end

--- a/test/cookbooks/test/recipes/server_install.rb
+++ b/test/cookbooks/test/recipes/server_install.rb
@@ -1,7 +1,6 @@
 if platform_family?('rhel')
   package 'libselinux-utils'
   selinux_state 'enforcing'
-  selinux_policy_install 'install'
 end
 
 mariadb_repository 'install'


### PR DESCRIPTION
This was missed in #326 unfortunately. In addition, switch to using `include Chef::Util::Selinux` since `Chef::Resource.include` doesn't seem to work and results in an undefined method error.

Lastly, remove use of `selinux_policy_install` in the test recipe to ensure we catch this issue in the future.

This fixes the following issue that was encountered:

```
Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '2'
---- Begin output of /usr/bin/make -f /usr/share/selinux/devel/Makefile mariadb-server.pp ----
STDOUT:
STDERR: make: /usr/share/selinux/devel/Makefile: No such file or directory
make: *** No rule to make target `/usr/share/selinux/devel/Makefile'.  Stop.
---- End output of /usr/bin/make -f /usr/share/selinux/devel/Makefile mariadb-server.pp ----
Ran /usr/bin/make -f /usr/share/selinux/devel/Makefile mariadb-server.pp returned 2
```

Signed-off-by: Lance Albertson <lance@osuosl.org>

## Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List
- [ ] All tests pass. See https://github.com/sous-chefs/mariadb/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
