### PR TITLE
Add sleep parameter install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## 4.2.2 - *2021-02-15*
+
+- Make sleep configurable in `apply-mariadb-root-password`
+
 ## 4.2.1 - *2021-01-25*
 
 - Ensure we run `selinux_policy_install` if selinux is enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-## 4.2.2 - *2021-02-15*
-
 - Make sleep configurable in `apply-mariadb-root-password`
 
 ## 4.2.1 - *2021-01-25*

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configures MariaDB'
 source_url       'https://github.com/sous-chefs/mariadb'
 issues_url       'https://github.com/sous-chefs/mariadb/issues'
 chef_version     '>= 15'
-version          '4.2.2'
+version          '4.2.1'
 
 supports 'ubuntu', '>= 18.04'
 supports 'debian', '>= 9.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs/Configures MariaDB'
 source_url       'https://github.com/sous-chefs/mariadb'
 issues_url       'https://github.com/sous-chefs/mariadb/issues'
 chef_version     '>= 15'
-version          '4.2.1'
+version          '4.2.2'
 
 supports 'ubuntu', '>= 18.04'
 supports 'debian', '>= 9.0'

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -28,7 +28,7 @@ property :external_pid_file, String,        default: lazy { "/var/run/mysql/#{ve
 property :password,          [String, nil], default: 'generate'
 property :port,              Integer,       default: 3306
 property :initdb_locale,     String,        default: 'UTF-8'
-property :install_sleep,     Integer,       default: 4,       desired_state: false
+property :install_sleep,     Integer,       default: 4, desired_state: false
 
 action :install do
   node.run_state['mariadb'] ||= {}

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -28,6 +28,7 @@ property :external_pid_file, String,        default: lazy { "/var/run/mysql/#{ve
 property :password,          [String, nil], default: 'generate'
 property :port,              Integer,       default: 3306
 property :initdb_locale,     String,        default: 'UTF-8'
+property :install_sleep,     Integer,       default: 4,       desired_state: false
 
 action :install do
   node.run_state['mariadb'] ||= {}
@@ -99,7 +100,7 @@ flush privileges;"
   execute 'apply-mariadb-root-password' do
     user 'mysql'
     # TODO, I really dislike the sleeps here, should come up with a better way to do this
-    command "(test -f #{pid_file} && kill `cat #{pid_file}` && sleep 3); /usr/sbin/mysqld -u root --pid-file=#{pid_file} --init-file=#{data_dir}/recovery.conf&>/dev/null& sleep 2 && (test -f #{pid_file} && kill `cat #{pid_file}`)"
+    command "(test -f #{pid_file} && kill `cat #{pid_file}` && sleep #{new_resource.install_sleep}); /usr/sbin/mysqld -u root --pid-file=#{pid_file} --init-file=#{data_dir}/recovery.conf&>/dev/null& sleep #{new_resource.install_sleep} && (test -f #{pid_file} && kill `cat #{pid_file}`)"
     notifies :enable, "service[#{platform_service_name}]", :before
     notifies :stop, "service[#{platform_service_name}]", :before
     notifies :create, 'file[generate-mariadb-root-password]', :before


### PR DESCRIPTION
## Description

Makes the sleep on server root password set configurable.

For some of our setups the given sleep was to short.

### Check List
- [x] All tests pass. See https://github.com/sous-chefs/mariadb/blob/master/TESTING.md
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
