### PR TITLE
Migrate to using selinux cookbook which incorporates selinux_policy cookbook resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Migrate to using `selinux` cookbook which incorporates `selinux_policy` cookbook resources
+
 ## 5.0.2 - *2021-08-30*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,12 +3,11 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_solo
-  product_name: chef
+  name: chef_infra
+  product_name: <%= ENV['CHEF_PRODUCT_NAME'] || 'chef' %>
   enforce_idempotency: true
   multiple_converge: 2
-  solo_rb:
-    treat_deprecation_warnings_as_errors: true
+  deprecations_as_errors: true
 
 verifier:
   name: inspec

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,4 +12,4 @@ supports 'ubuntu', '>= 18.04'
 supports 'debian', '>= 9.0'
 supports 'centos', '>= 7.0'
 
-depends 'selinux_policy', '~> 2.4'
+depends 'selinux', '>= 6.0'

--- a/resources/galera_configuration.rb
+++ b/resources/galera_configuration.rb
@@ -63,7 +63,7 @@ action :bootstrap do
   ruby_block 'bootstrap galera cluster' do
     block do
       shell_out!('galera_new_cluster')
-      node.normal['mariadb']['galera']['bootstrapped'] = true # rubocop:disable ChefCorrectness/NodeNormal
+      node.normal['mariadb']['galera']['bootstrapped'] = true # rubocop:disable Chef/Correctness/NodeNormal
     end
     notifies :stop, "service[#{platform_service_name}]", :before
     not_if { galera_cluster_bootstrapped? && bootstrapped_attribute_set? }
@@ -73,7 +73,7 @@ end
 action :join do
   ruby_block 'join galera cluster' do
     block do
-      node.normal['mariadb']['galera']['bootstrapped'] = true if galera_cluster_joined? # rubocop:disable ChefCorrectness/NodeNormal
+      node.normal['mariadb']['galera']['bootstrapped'] = true if galera_cluster_joined? # rubocop:disable Chef/Correctness/NodeNormal
     end
     notifies :restart, "service[#{platform_service_name}]", :before
     not_if { galera_cluster_joined? && bootstrapped_attribute_set? }

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -42,10 +42,10 @@ action :install do
 
   package server_pkg_name
 
-  selinux_policy_install 'mariadb' if selinux_enabled?
+  selinux_install 'mariadb' if selinux_enabled?
 
   %w(mariadb-server mariadb).each do |m|
-    selinux_policy_module m do
+    selinux_module m do
       content lazy { ::File.read("/usr/share/mysql/policy/selinux/#{m}.te") }
       only_if { selinux_enabled? }
     end


### PR DESCRIPTION
This finishes up fixing `unified_mode` issues related to this cookbook. Other fixes includes:

- Switch to using `chef_infra` for provisioner
- Add `CHEF_PRODUCT_NAME` env var for Cinc users
- Fix `deprecations_as_errors` usage

Signed-off-by: Lance Albertson <lance@osuosl.org>
