### PR TITLE
Set and allow root password authentication on MariaDB 10.4+ #256

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,8 @@ jobs:
         suite:
           - 'repository'
           - 'client-install'
-          - 'server-install'
+          - 'server-install-103'
+          - 'server-install-104'
           - 'configuration'
           - 'server-configuration'
           - 'resources'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Fix root password cannot be manually set on 10.4+
+
 ## 5.1.0 - *2021-10-13*
 
 - Migrate to using `selinux` cookbook which incorporates `selinux_policy` cookbook resources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Testing MariaDB 10.4 server install
 - Fix root password cannot be manually set on 10.4+
 
 ## 5.1.0 - *2021-10-13*

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -27,9 +27,22 @@ suites:
   - name: client_install
     run_list:
       - recipe[test::client_install]
-  - name: server_install
+  - name: server_install_10.3
     run_list:
       - recipe[test::server_install]
+    attributes:
+      mariadb_server_test_version: '10.3'
+    verifier:
+      inspec_tests:
+        - path: test/integration/server_install
+  - name: server_install_10.4
+    run_list:
+      - recipe[test::server_install]
+    attributes:
+      mariadb_server_test_version: '10.4'
+    verifier:
+      inspec_tests:
+        - path: test/integration/server_install
   - name: configuration
     run_list:
       - recipe[test::configuration]

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -29,7 +29,7 @@ property :external_pid_file, String,        default: lazy { "/var/run/mysql/#{ve
 property :password,          [String, nil], default: 'generate'
 property :port,              Integer,       default: 3306
 property :initdb_locale,     String,        default: 'UTF-8'
-property :install_sleep,     Integer,       default: 4, desired_state: false
+property :install_sleep,     Integer,       default: 5, desired_state: false
 
 action :install do
   node.run_state['mariadb'] ||= {}
@@ -73,11 +73,11 @@ action :create do
   # Generate a random password or set a password defined with node['mariadb']['server_root_password'].
   # The password is set or change at each run. It is good for security if you choose to set a random password and
   # allow you to change the root password if needed.
-  set_password_command = 'USE mysql;'
+  set_password_command = "USE mysql;\n"
   set_password_command += if new_resource.version =~ /^10\.[0-3]/
-                            "UPDATE user SET password=PASSWORD('#{mariadb_root_password}') WHERE User='root';"
+                            "UPDATE user SET password=PASSWORD('#{mariadb_root_password}') WHERE User='root';\n"
                           else
-                            "ALTER USER root@localhost IDENTIFIED VIA unix_socket OR mysql_native_password USING PASSWORD('#{mariadb_root_password}');"
+                            "ALTER USER root@localhost IDENTIFIED VIA unix_socket OR mysql_native_password USING PASSWORD('#{mariadb_root_password}');\n"
                           end
   set_password_command += "FLUSH PRIVILEGES;\n"
 

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -79,9 +79,8 @@ action :create do
     group 'root'
     mode '640'
     sensitive true
-    content "use mysql;
-update user set password=PASSWORD('#{mariadb_root_password}') where User='root';
-flush privileges;"
+    content "ALTER USER root@localhost IDENTIFIED VIA unix_socket OR mysql_native_password USING PASSWORD('#{mariadb_root_password}');
+FLUSH PRIVILEGES;"
     action :nothing
   end
 

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -74,7 +74,7 @@ action :create do
   # The password is set or change at each run. It is good for security if you choose to set a random password and
   # allow you to change the root password if needed.
   set_password_command = "USE mysql;\n"
-  set_password_command += if new_resource.version =~ /^10\.[0-3]/
+  set_password_command += if new_resource.version.to_f <= 10.3
                             "UPDATE user SET password=PASSWORD('#{mariadb_root_password}') WHERE User='root';\n"
                           else
                             "ALTER USER root@localhost IDENTIFIED VIA unix_socket OR mysql_native_password USING PASSWORD('#{mariadb_root_password}');\n"

--- a/test/cookbooks/test/attributes/default.rb
+++ b/test/cookbooks/test/attributes/default.rb
@@ -1,0 +1,2 @@
+# Which default MariaDB version to use for testing (can be overridden in kitchen.yml)
+default['mariadb_server_test_version'] = '10.3'

--- a/test/cookbooks/test/recipes/client_install.rb
+++ b/test/cookbooks/test/recipes/client_install.rb
@@ -1,4 +1,4 @@
 # This resource should install the mariadb client
 mariadb_client_install 'mariadb client' do
-  version '10.3'
+  version node['mariadb_server_test_version']
 end

--- a/test/cookbooks/test/recipes/datadir.rb
+++ b/test/cookbooks/test/recipes/datadir.rb
@@ -1,7 +1,7 @@
 include_recipe 'test::server_install'
 
 mariadb_server_configuration 'MariaDB Server Configuration' do
-  version '10.3'
+  version node['mariadb_server_test_version']
   mysqld_datadir '/opt/mysql'
   innodb_buffer_pool_size '256M'
 end

--- a/test/cookbooks/test/recipes/galera_configuration.rb
+++ b/test/cookbooks/test/recipes/galera_configuration.rb
@@ -1,7 +1,7 @@
 include_recipe 'test::server_configuration'
 
 mariadb_server_configuration 'MariaDB Server Configuration' do
-  version '10.3'
+  version node['mariadb_server_test_version']
 end
 
 yum_repository 'epel' do
@@ -11,7 +11,7 @@ yum_repository 'epel' do
 end
 
 mariadb_galera_configuration 'MariaDB Galera Configuration' do
-  version '10.3'
+  version node['mariadb_server_test_version']
   wsrep_sst_method 'mariabackup'
   action [:create, :bootstrap]
 end

--- a/test/cookbooks/test/recipes/port.rb
+++ b/test/cookbooks/test/recipes/port.rb
@@ -1,7 +1,7 @@
 include_recipe 'test::server_install'
 
 mariadb_server_configuration 'MariaDB Server Configuration' do
-  version '10.3'
+  version node['mariadb_server_test_version']
   client_port 3307
   mysqld_port 3307
 end

--- a/test/cookbooks/test/recipes/repository.rb
+++ b/test/cookbooks/test/recipes/repository.rb
@@ -1,3 +1,3 @@
 mariadb_repository 'mariadb repo' do
-  version '10.3'
+  version node['mariadb_server_test_version']
 end

--- a/test/cookbooks/test/recipes/server_configuration.rb
+++ b/test/cookbooks/test/recipes/server_configuration.rb
@@ -1,5 +1,5 @@
 include_recipe 'test::server_install'
 
 mariadb_server_configuration 'MariaDB Server Configuration' do
-  version '10.3'
+  version node['mariadb_server_test_version']
 end

--- a/test/cookbooks/test/recipes/server_install.rb
+++ b/test/cookbooks/test/recipes/server_install.rb
@@ -3,10 +3,13 @@ if platform_family?('rhel')
   selinux_state 'enforcing'
 end
 
-mariadb_repository 'install'
+mariadb_repository 'install' do
+  version node['mariadb_server_test_version']
+end
 
 mariadb_server_install 'package' do
   action [:install, :create]
+  version node['mariadb_server_test_version']
   password 'gsql'
 end
 


### PR DESCRIPTION
# Description

Describe what this change achieves

Since MariaDB 10.4, the Ubuntu/Debian packages configure the root@localhost account with only the `unix_socket` authentication plugin. When setting the root password, we must also activate the `mysql_native_password` plugin, otherwise the password is not set and a warning is issued instead:

```
ERROR: 1356  View 'mysql.user' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them
```

This fix the content of the `/var/lib/mysql/recovery.conf ` file to properly set the password

## Issues Resolved

#256 

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
