### PR TITLE
Install mariadb.pp SELinux policy instead of building mariadb-server.te policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Install `mariadb.pp` SELinux policy instead of building `mariadb-server.te` policy
+
 ## 5.2.3 - *2022-02-14*
 
 - Remove delivery and move to calling RSpec directly via a reusable workflow

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -44,11 +44,12 @@ action :install do
 
   selinux_install 'mariadb' if selinux_enabled?
 
-  %w(mariadb-server mariadb).each do |m|
-    selinux_module m do
-      content lazy { ::File.read("/usr/share/mysql/policy/selinux/#{m}.te") }
-      only_if { selinux_enabled? }
-    end
+  # This should get automatically installed via the package, but in case it doesn't ensure it does here
+  # https://mariadb.com/kb/en/selinux/
+  selinux_module 'mariadb' do
+    base_dir '/usr/share/mysql/policy/selinux'
+    only_if { selinux_enabled? }
+    action :install
   end
 end
 

--- a/test/cookbooks/test/recipes/server_install.rb
+++ b/test/cookbooks/test/recipes/server_install.rb
@@ -1,5 +1,5 @@
 if platform_family?('rhel')
-  package 'libselinux-utils'
+  selinux_install 'default'
   selinux_state 'enforcing'
 end
 


### PR DESCRIPTION
This fixes a problem when trying to build the `mariadb-server.te` policy on RHEL-based systems. It appears the te policy file includes a policy which isn't on the systems anymore and breaks installations. Upon further investigation, it appears this specific policy isn't need anymore per upstream documentation [1]. In addition, it looks as though the package already loads the pp policy but let's ensure it's loaded as well.

Error this is resolving:

```
Compiling targeted mariadb-server module
/usr/bin/checkmodule:  loading policy configuration from tmp/mariadb-server.tmp
mariadb-server.te:81:ERROR 'unknown type usermodehelper_t' at token ';' on line 1121:
allow mysqld_t usermodehelper_t:file { read open };
allow mysqld_t tmp_t:file { append create read write open getattr unlink setattr };
/usr/bin/checkmodule:  error(s) encountered while parsing configuration
```

[1] https://mariadb.com/kb/en/selinux/

Signed-off-by: Lance Albertson <lance@osuosl.org>
