### PR TITLE
Support and test 10.3+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,29 +26,75 @@ jobs:
           - centos-7
           - centos-stream-8
           - debian-10
+          - debian-11
           - rockylinux-8
           - ubuntu-1804
           - ubuntu-2004
-          # TODO: need to update to using newer versions of MariaDB for this to
-          # work
-          # - debian-11
-          # TODO: need to update to using newer versions of MariaDB for this to
-          # work
+          # Latest fedora (38 at time of writing) does not have any mariadb packages yet
           # - fedora-latest
         suite:
           - "repository"
           - "client-install"
           - "client-distro-install"
-          - "server-install-103"
-          - "server-install-104"
+          - "server-install"
+          - "server-install-1011"
           - "server-distro-install"
           - "configuration"
           - "server-configuration"
+          - "server-configuration-1011"
           - "resources"
+          - "resources-1011"
           - "replication"
+          - "replication-1011"
           - "datadir"
           - "port"
           - "galera-configuration"
+          - "galera-configuration-1011"
+        exclude:
+          - os: ubuntu-1804
+            suite: "server-install-1011"
+          - os: ubuntu-1804
+            suite: "server-configuration-1011"
+          - os: ubuntu-1804
+            suite: "resources-1011"
+          - os: ubuntu-1804
+            suite: "replication-1011"
+          - os: ubuntu-1804
+            suite: "galera-configuration-1011"
+          - os: centos-7
+            suite: "server-install-1011"
+          - os: centos-7
+            suite: "server-configuration-1011"
+          - os: centos-7
+            suite: "resources-1011"
+          - os: centos-7
+            suite: "replication-1011"
+          - os: centos-7
+            suite: "galera-configuration-1011"
+          - os: debian-11
+            suite: "repository"
+          - os: debian-11
+            suite: "client-install"
+          - os: debian-11
+            suite: "client-distro-install"
+          - os: debian-11
+            suite: "server-install"
+          - os: debian-11
+            suite: "server-distro-install"
+          - os: debian-11
+            suite: "configuration"
+          - os: debian-11
+            suite: "server-configuration"
+          - os: debian-11
+            suite: "resources"
+          - os: debian-11
+            suite: "replication"
+          - os: debian-11
+            suite: "datadir"
+          - os: debian-11
+            suite: "port"
+          - os: debian-11
+            suite: "galera-configuration"
       fail-fast: false
 
     steps:
@@ -59,6 +105,7 @@ jobs:
       - name: Disable apparmor for mysqld
         run: |
           set -x
+          sudo apt-get update
           sudo apt-get -y remove mysql-server --purge
           sudo apt-get -y install apparmor-profiles
           sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,9 @@ jobs:
           - "replication"
           - "replication-1011"
           - "datadir"
+          - "datadir-1011"
           - "port"
+          - "port-1011"
           - "galera-configuration"
           - "galera-configuration-1011"
         exclude:
@@ -60,6 +62,10 @@ jobs:
           - os: ubuntu-1804
             suite: "replication-1011"
           - os: ubuntu-1804
+            suite: "datadir-1011"
+          - os: ubuntu-1804
+            suite: "port-1011"
+          - os: ubuntu-1804
             suite: "galera-configuration-1011"
           - os: centos-7
             suite: "server-install-1011"
@@ -69,6 +75,10 @@ jobs:
             suite: "resources-1011"
           - os: centos-7
             suite: "replication-1011"
+          - os: centos-7
+            suite: "datadir-1011"
+          - os: centos-7
+            suite: "port-1011"
           - os: centos-7
             suite: "galera-configuration-1011"
           - os: debian-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Remove version suffix from package names for debian-based OSes
+- Put the mysql control credentials in to a reusable method
+- Remove unnecessary method arguments and setting of version in run_state
+- Fix default_pid_file method
+- Add tests for 10.11
+- Extend unit tests
+- Fix libgalera install path issue on MariaDB 10.4+
+- Fix resource idempotency issues with MariaDB 10.5 and 10.6
+- Simplify conditionals in helpers.rb
+- Alter yum repo path to match what MariaDB recommend
+
 ## 5.2.19 - *2023-04-18*
 
 - Patched the ability to use SELinux with `setup_repo` disabled

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -17,12 +17,12 @@ verifier:
 
 platforms:
   - name: almalinux-8
-  - name: amazonlinux-2
+  # - name: amazonlinux-2023
   - name: debian-10
   - name: debian-11
   - name: centos-7
   - name: centos-stream-8
-  - name: fedora-latest
+  # - name: fedora-latest
   - name: ubuntu-18.04
   - name: ubuntu-20.04
   - name: rockylinux-8
@@ -31,49 +31,129 @@ suites:
   - name: repository
     run_list:
       - recipe[test::repository]
+    excludes:
+      - debian-11
   - name: client_install
     run_list:
       - recipe[test::client_install]
+    excludes:
+      - debian-11
   - name: client_distro_install
     run_list:
       - recipe[test::client_distro_install]
-  - name: server_install_10.3
+  - name: server_install
+    run_list:
+      - recipe[test::server_install]
+    excludes:
+      - debian-11
+  - name: server_install_10.11
     run_list:
       - recipe[test::server_install]
     attributes:
-      mariadb_server_test_version: '10.3'
+      mariadb_server_test_version: '10.11'
     verifier:
       inspec_tests:
         - path: test/integration/server_install
-  - name: server_install_10.4
-    run_list:
-      - recipe[test::server_install]
-    attributes:
-      mariadb_server_test_version: '10.4'
-    verifier:
-      inspec_tests:
-        - path: test/integration/server_install
+    excludes:
+      - ubuntu-18.04
+      - centos-7
   - name: server_distro_install
     run_list:
       - recipe[test::server_distro_install]
   - name: configuration
     run_list:
       - recipe[test::configuration]
+    excludes:
+      - debian-11
   - name: server_configuration
     run_list:
       - recipe[test::server_configuration]
+    excludes:
+      - debian-11
+  - name: server_configuration_10.11
+    run_list:
+      - recipe[test::server_configuration]
+    attributes:
+      mariadb_server_test_version: '10.11'
+    verifier:
+      inspec_tests:
+        - path: test/integration/server_configuration
+    excludes:
+      - ubuntu-18.04
+      - centos-7
   - name: resources
     run_list:
       - recipe[test::user_database]
+    excludes:
+      - debian-11
+  - name: resources_10.11
+    run_list:
+      - recipe[test::user_database]
+    attributes:
+      mariadb_server_test_version: '10.11'
+    verifier:
+      inspec_tests:
+        - path: test/integration/resources
+    excludes:
+      - ubuntu-18.04
+      - centos-7
   - name: replication
     run_list:
       - recipe[test::replication]
+    excludes:
+      - debian-11
+  - name: replication_10.11
+    run_list:
+      - recipe[test::replication]
+    attributes:
+      mariadb_server_test_version: '10.11'
+    verifier:
+      inspec_tests:
+        - path: test/integration/replication
+    excludes:
+      - ubuntu-18.04
+      - centos-7
   - name: datadir
     run_list:
       - recipe[test::datadir]
+    excludes:
+      - debian-11
+  - name: datadir_10.11
+    run_list:
+      - recipe[test::datadir]
+    verifier:
+      inspec_tests:
+        - path: test/integration/datadir
+    excludes:
+      - ubuntu-18.04
+      - centos-7
   - name: port
     run_list:
       - recipe[test::port]
+    excludes:
+      - debian-11
+  - name: port_10.11
+    run_list:
+      - recipe[test::port]
+    verifier:
+      inspec_tests:
+        - path: test/integration/port
+    excludes:
+      - ubuntu-18.04
+      - centos-7
   - name: galera_configuration
     run_list:
       - recipe[test::galera_configuration]
+    excludes:
+      - debian-11
+  - name: galera_configuration_10.11
+    run_list:
+      - recipe[test::galera_configuration]
+    attributes:
+      mariadb_server_test_version: '10.11'
+    verifier:
+      inspec_tests:
+        - path: test/integration/galera_configuration
+    excludes:
+      - ubuntu-18.04
+      - centos-7

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -26,9 +26,6 @@ property :password,          [String, nil], default: 'generate'
 property :install_sleep,     Integer,       default: 5, desired_state: false
 
 action :install do
-  node.run_state['mariadb'] ||= {}
-  node.run_state['mariadb']['version'] = new_resource.version
-
   mariadb_client_install 'Install MariaDB Client' do
     version new_resource.version
     setup_repo new_resource.setup_repo

--- a/spec/libraries/helper_spec.rb
+++ b/spec/libraries/helper_spec.rb
@@ -7,26 +7,58 @@ RSpec.describe MariaDBCookbook::Helpers do
   end
   subject { DummyClass.new }
 
-  describe '#data_dir(version)' do
+  describe 'helpers' do
     before do
-      allow(subject).to receive(:[]).with('platform_family').and_return(platform_family)
+      allow(subject).to receive(:[]).with(:platform_family).and_return(platform_family)
+      allow(subject).to receive(:mariadb_version).and_return(Gem::Version.new(mariadb_version))
     end
 
-    let(:version) { '10.3' }
-
-    context 'with rhel family and MariaDB 10.3' do
+    context 'with rhel family' do
       let(:platform_family) { 'rhel' }
+      let(:mariadb_version) { '10.3' }
 
-      it 'returns the correct path' do
-        expect(subject.data_dir(version)).to eq '/var/lib/mysql'
+      # All common to RHEL
+      it 'returns the correct paths' do
+        expect(subject.conf_dir).to eq '/etc'
+        expect(subject.ext_conf_dir).to eq '/etc/my.cnf.d'
+        expect(subject.default_socket).to eq '/var/lib/mysql/mysql.sock'
+        expect(subject.default_pid_file).to eq '/var/run/mariadb/mariadb.pid'
+      end
+
+      it 'returns the correct libgalera path' do
+        expect(subject.default_libgalera_smm_path).to eq '/usr/lib64/galera/libgalera_smm.so'
+      end
+
+      it 'returns the correct encoding and collation' do
+        expect(subject.default_encoding).to eq 'utf8'
+        expect(subject.default_collation).to eq 'utf8_general_ci'
+      end
+
+      # MariaDB version differences
+      context 'with mariadb 10.11' do
+        let(:mariadb_version) { '10.11' }
+
+        it 'returns the correct libgalera path' do
+          expect(subject.default_libgalera_smm_path).to eq '/usr/lib64/galera-4/libgalera_smm.so'
+        end
+
+        it 'returns the correct encoding and collation' do
+          expect(subject.default_encoding).to eq 'utf8mb3'
+          expect(subject.default_collation).to eq 'utf8mb3_general_ci'
+        end
       end
     end
 
-    context 'with debian family and MariaDB 10.3' do
+    context 'with debian family' do
       let(:platform_family) { 'debian' }
+      let(:mariadb_version) { '10.3' }
 
-      it 'returns the correct path' do
-        expect(subject.data_dir(version)).to eq '/var/lib/mysql'
+      it 'returns the correct paths' do
+        expect(subject.conf_dir).to eq '/etc/mysql'
+        expect(subject.ext_conf_dir).to eq '/etc/mysql/conf.d'
+        expect(subject.default_socket).to eq '/var/run/mysqld/mysqld.sock'
+        expect(subject.default_pid_file).to eq '/var/run/mysqld/mysqld.pid'
+        expect(subject.default_libgalera_smm_path).to eq '/usr/lib/galera/libgalera_smm.so'
       end
     end
   end

--- a/test/cookbooks/test/recipes/client_install.rb
+++ b/test/cookbooks/test/recipes/client_install.rb
@@ -2,3 +2,8 @@
 mariadb_client_install 'mariadb client' do
   version node['mariadb_server_test_version']
 end
+
+# Save the intended mariadb version to a file for easy reference in inspec
+file '/tmp/mariadb_version' do
+  content node['mariadb_server_test_version']
+end

--- a/test/cookbooks/test/recipes/galera_configuration.rb
+++ b/test/cookbooks/test/recipes/galera_configuration.rb
@@ -11,3 +11,8 @@ mariadb_galera_configuration 'MariaDB Galera Configuration' do
   wsrep_sst_method 'mariabackup'
   action [:create, :bootstrap]
 end
+
+# Save the number of CPU cores to a file for easy reference in inspec
+file '/tmp/cpu_cores' do
+  content node['cpu']['total'].to_s
+end

--- a/test/cookbooks/test/recipes/repository.rb
+++ b/test/cookbooks/test/recipes/repository.rb
@@ -1,3 +1,8 @@
 mariadb_repository 'mariadb repo' do
   version node['mariadb_server_test_version']
 end
+
+# Save the intended mariadb version to a file for easy reference in inspec
+file '/tmp/mariadb_version' do
+  content node['mariadb_server_test_version']
+end

--- a/test/cookbooks/test/recipes/server_install.rb
+++ b/test/cookbooks/test/recipes/server_install.rb
@@ -20,3 +20,8 @@ find_resource(:service, 'mariadb') do
   supports restart: true, status: true, reload: true
   action [:enable, :start]
 end
+
+# Save the intended mariadb version to a file for easy reference in inspec
+file '/tmp/mariadb_version' do
+  content node['mariadb_server_test_version']
+end

--- a/test/integration/client_install/controls/client_install_spec.rb
+++ b/test/integration/client_install/controls/client_install_spec.rb
@@ -2,7 +2,9 @@ describe command('/usr/bin/mysql --help') do
   its('exit_status') { should eq 0 }
 end
 
+version = file('/tmp/mariadb_version').content
+
 describe command('/usr/bin/mysql -V') do
-  its('stdout') { should match(%r{\/usr\/bin\/mysql  Ver 15\.1 Distrib 10\.3\.[0-9]+-MariaDB, for [A-Za-z0-9-]+inux[A-Za-z0-9\-]* \(x86_64\) using readline 5\.[1-2]}) }
+  its('stdout') { should match(%r{\/usr\/bin\/mysql  Ver 15\.1 Distrib #{version}\.\d+-MariaDB}) }
   its('exit_status') { should eq 0 }
 end

--- a/test/integration/configuration/controls/configuration_spec.rb
+++ b/test/integration/configuration/controls/configuration_spec.rb
@@ -3,7 +3,7 @@
 # includedir = '/etc/mysql/conf.d'
 extra_config_file = '/etc/mysql/conf.d/extra_innodb.cnf'
 case os[:family]
-when 'centos', 'redhat', 'amazon'
+when 'centos', 'redhat', 'amazon', 'fedora'
   # includedir = '/etc/my.cnf.d'
   extra_config_file = '/etc/my.cnf.d/extra_innodb.cnf'
 end

--- a/test/integration/datadir/controls/datadir_changed_spec.rb
+++ b/test/integration/datadir/controls/datadir_changed_spec.rb
@@ -11,10 +11,10 @@ control 'mariadb_replication' do
     it { should be_listening }
   end
 
-  includedir = '/etc/mysql/conf.d'
-  mysql_config_file = '/etc/mysql/my.cnf'
-  case os[:family]
-  when 'centos', 'redhat'
+  if os.debian?
+    includedir = '/etc/mysql/conf.d'
+    mysql_config_file = '/etc/mysql/my.cnf'
+  else
     includedir = '/etc/my.cnf.d'
     mysql_config_file = '/etc/my.cnf'
   end

--- a/test/integration/port/controls/port_changed_spec.rb
+++ b/test/integration/port/controls/port_changed_spec.rb
@@ -10,10 +10,10 @@ control 'port_changed' do
     it { should be_listening }
   end
 
-  includedir = '/etc/mysql/conf.d'
-  mysql_config_file = '/etc/mysql/my.cnf'
-  case os[:family]
-  when 'centos', 'redhat'
+  if os.debian?
+    includedir = '/etc/mysql/conf.d'
+    mysql_config_file = '/etc/mysql/my.cnf'
+  else
     includedir = '/etc/my.cnf.d'
     mysql_config_file = '/etc/my.cnf'
   end

--- a/test/integration/repository/controls/repository_spec.rb
+++ b/test/integration/repository/controls/repository_spec.rb
@@ -1,31 +1,15 @@
 # frozen_string_literal: true
 
-case os.family
+version = file('/tmp/mariadb_version').content
 
-when 'redhat'
-
-  describe yum.repo('mariadb10.3') do
+if os.debian?
+  describe apt("http://mariadb.mirrors.ovh.net/MariaDB/repo/#{version}/#{os.name}") do
     it { should exist }
     it { should be_enabled }
   end
-
-when 'debian'
-
-  case os.name
-
-  when 'debian'
-
-    describe apt('http://mariadb.mirrors.ovh.net/MariaDB/repo/10.3/debian') do
-      it { should exist }
-      it { should be_enabled }
-    end
-
-  when 'ubuntu'
-
-    describe apt('http://mariadb.mirrors.ovh.net/MariaDB/repo/10.3/ubuntu') do
-      it { should exist }
-      it { should be_enabled }
-    end
-
+else
+  describe yum.repo("mariadb#{version}") do
+    it { should exist }
+    it { should be_enabled }
   end
 end

--- a/test/integration/resources/controls/user_spec.rb
+++ b/test/integration/resources/controls/user_spec.rb
@@ -42,6 +42,8 @@ control 'mariadb_user' do
   end
 
   describe sql.query("show grants for 'spaces'@'127.0.0.1'") do
-    its('output') { should include 'GRANT LOCK TABLES, REPLICATION CLIENT ON *.* TO `spaces`@`127.0.0.1`' }
+    mariadb_version = Gem::Version.new(file('/tmp/mariadb_version').content)
+    repl_priv = mariadb_version >= Gem::Version.new('10.5') ? 'BINLOG MONITOR' : 'REPLICATION CLIENT'
+    its('output') { should include "GRANT LOCK TABLES, #{repl_priv} ON *.* TO `spaces`@`127.0.0.1`" }
   end
 end

--- a/test/integration/server_configuration/controls/server_configuration_spec.rb
+++ b/test/integration/server_configuration/controls/server_configuration_spec.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-# includedir = '/etc/mysql/conf.d'
-mysql_config_file = '/etc/mysql/my.cnf'
-case os[:family]
-when 'centos', 'redhat', 'amazon'
+if os.debian? # rubocop:disable Style/ConditionalAssignment
+  # includedir = '/etc/mysql/conf.d'
+  mysql_config_file = '/etc/mysql/my.cnf'
+else
   # includedir = '/etc/my.cnf.d'
   mysql_config_file = '/etc/my.cnf'
 end

--- a/test/integration/server_install/controls/server_install_spec.rb
+++ b/test/integration/server_install/controls/server_install_spec.rb
@@ -1,7 +1,16 @@
 # frozen_string_literal: true
 
+version = file('/tmp/mariadb_version').content
+
+describe command('mysqld -V') do
+  its('stdout') { should match(/mysqld  Ver #{version}\.\d+-MariaDB/) }
+  its('exit_status') { should eq 0 }
+end
+
 describe service('mysql') do
   it { should be_installed }
   it { should be_enabled }
   it { should be_running }
 end
+
+include_controls 'client_install'


### PR DESCRIPTION
I combed through version 10.3 to 10.11 and discovered that some changes
occured in 10.4, 10.5, 10.6 and 10.11 that made some resources of this
cookbook not work.

With 10.11, the package in the mariadb repo does not have the version
appended to it anymore. The `mariadb-[client|server|common|etc]-<version>`
pattern redirects to the package without the version suffix anyway, so
installing without the suffix should be sufficient for all mariadb
versions on debian.

MariaDB 10.4 libgalera_smm.so changed its install location on RHEL based
systems from /usr/lib/galera to /usr/lib/galera-4. The helper now
detects the version and adapts accordingly.

MariaDB 10.5 changed the REPLICATION CLIENT role to BINLOG MONITOR. This
made the user resource not idempotent because we were checking for the
wrong value. The resource now detects version and adapts accordingly.

In MariaDB 10.6 the default database encoding and collation changed to
utf8mb3. This made the database resource not idempotent as it was
testing for the wrong value. The resource now detects the version and
adapts accordingly.

Expanded tests of mariadb 10.11 to all suites and excluded the suites
that would not work with 10.3/10.11.

Normalised some conditionals in helpers.rb.

Normalised the method for constructing mysql control connections for the
database and user resources.

Altered the yum repo path so it matches what mariadb recommends. This
obviates the need to test for the kernel and change the yum path
accordingly.

The `default_pid_file` method was giving us the wrong path on debian
when called from a resource that did not have the `setup_repo`
property. It only really matters when setting the root password in
the `server_install` resource, but that code needs a revisit anyway
which I will save for a future PR.

Resolves #353.