### PR TITLE
Clean server install resource

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,13 @@ name: CI
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@2.0.1
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@2.0.2
+    permissions:
+      actions: write
+      checks: write
+      pull-requests: write
+      statuses: write
+      issues: write
 
   integration:
     needs: lint-unit
@@ -28,47 +34,6 @@ jobs:
           - ubuntu-1804
           - ubuntu-2004
           - rockylinux-8
-        suite:
-          - "repository"
-          - "client-install"
-          - "server-install-103"
-          - "server-install-104"
-          - "configuration"
-          - "server-configuration"
-          - "resources"
-          - "replication"
-          - "datadir"
-          - "port"
-          - "galera-configuration"
-      fail-fast: false
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v3
-      - name: Install Chef
-        uses: actionshub/chef-install@2.0.4
-      - name: Disable apparmor for mysqld
-        run: |
-          set -x
-          sudo apt-get -y remove mysql-server --purge
-          sudo apt-get -y install apparmor-profiles
-          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
-      - name: Dokken
-        uses: actionshub/test-kitchen@2.1.0
-        env:
-          CHEF_LICENSE: accept-no-persist
-          KITCHEN_LOCAL_YAML: kitchen.dokken.yml
-        with:
-          suite: ${{ matrix.suite }}
-          os: ${{ matrix.os }}
-
-  integration-amazonlinux:
-    needs: lint-unit
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        os:
-          - amazonlinux-2
         suite:
           - "repository"
           - "client-install"

--- a/documentation/resource_mariadb_client_install.md
+++ b/documentation/resource_mariadb_client_install.md
@@ -10,15 +10,15 @@ This resource installs mariadb client packages.
 
 Name                | Types             | Description                                                   | Default                                   | Required?
 ------------------- | ----------------- | ------------------------------------------------------------- | ----------------------------------------- | ---------
-`version`           | String            | Version of MariaDB to install                                 | `10.3`                                    | no
+`version`           | String            | Version of MariaDB to install                                 | `10.11`                                   | no
 `setup_repo`        | Boolean           | Define if you want to add the MariaDB repository              | `true`                                    | no
 
 ### Examples
 
-To install '10.3' version:
+To install '10.11' version:
 
 ```ruby
 mariadb_client_install 'MariaDB Client install' do
-  version '10.3'
+  version '10.11'
 end
 ```

--- a/documentation/resource_mariadb_galera_configuration.md
+++ b/documentation/resource_mariadb_galera_configuration.md
@@ -22,7 +22,7 @@ Name                                   | Types             | Description        
 `innodb_flush_log_at_trx_commit`       | Integer           |                                                               | `2`                                       | no
 `options`                              | Hash              |                                                               | `{}`                                      | no
 `server_id`                            | Integer           |                                                               | `100`                                     | no
-`version`                              | String            | Version of MariaDB installed                                  | `10.3`                                    | no
+`version`                              | String            | Version of MariaDB installed                                  | `10.11`                                   | no
 `wsrep_node_address_interface`         | String, NilClass  |                                                               | `nil`                                     | no
 `wsrep_node_incoming_address_interface`| String, NilClass  |                                                               | `nil`                                     | no
 `wsrep_node_port`                      | Integer, NilClass |                                                               | `nil`                                     | no
@@ -50,7 +50,7 @@ Then use a Chef search to find other nodes and add these hosts to the gcomm addr
 
 ```ruby
 mariadb_galera_configuration 'MariaDB Galera Server Configuration' do
-  version '10.3'
+  version '10.11'
   cluster_name 'my_cluster_name'
   cluster_search_query "mycookbook_galera_cluster_name:my_cluster_name"
 end
@@ -60,7 +60,7 @@ If you don't want to have a dynamic node galera node management, you can manuall
 
 ```ruby
 mariadb_galera_configuration 'MariaDB Galera Server Configuration' do
-  version '10.3'
+  version '10.11'
   cluster_name 'my_cluster_name'
   gcomm_address 'gcomm://node1.fqdn,node2.fqdn'
 end
@@ -74,7 +74,7 @@ Following on from the previous example, to do this you should specific the `:boo
 
 ```ruby
 mariadb_galera_configuration 'MariaDB Galera Server Configuration' do
-  version '10.3'
+  version '10.11'
   cluster_name 'my_cluster_name'
   cluster_search_query "mycookbook_galera_cluster_name:my_cluster_name AND mariadb_galera_bootstrapped:true"
   action [:create, :bootstrap]
@@ -85,7 +85,7 @@ This should only be done by one node in cluster you're going to create, other no
 
 ```ruby
 mariadb_galera_configuration 'MariaDB Galera Server Configuration' do
-  version '10.3'
+  version '10.11'
   cluster_name 'my_cluster_name'
   cluster_search_query "mycookbook_galera_cluster_name:my_cluster_name AND mariadb_galera_bootstrapped:true"
   action [:create, :join]

--- a/documentation/resource_mariadb_replication.md
+++ b/documentation/resource_mariadb_replication.md
@@ -15,7 +15,7 @@ The resource name need to be 'default' if your don't want to use a named connect
 
 Name                                   | Types             | Description                                                   | Default                                   | Required?
 ---------------------------------------| ----------------- | ------------------------------------------------------------- | ----------------------------------------- | ---------
-`version`                              | String            | Version of MariaDB installed                                  | `10.3`                                    | no
+`version`                              | String            | Version of MariaDB installed                                  | `10.11`                                   | no
 `cookbook`                             | String            |                                                               | `mariadb`                                 | no
 `connection_name`                      | String            | The resource name                                             |                                           | yes
 `host`                                 | String, nil       |                                                               | `localhost`                               | no

--- a/documentation/resource_mariadb_repository.md
+++ b/documentation/resource_mariadb_repository.md
@@ -10,16 +10,16 @@ It installs the mariadb.org apt or yum repository
 
 Name                | Types             | Description                                                   | Default                                      | Required?
 ------------------- | ----------------- | ------------------------------------------------------------- | -------------------------------------------- | ---------
-`version`           | String            | Version of MariaDB to install                                 | `10.3`                                       | no
+`version`           | String            | Version of MariaDB to install                                 | `10.11`                                      | no
 `apt_gpg_keyserver` | String            | The key server url in which grab the gpg key                  | `keyserver.ubuntu.com`                       | no
 `apt_repository_uri`| String            | The repository url                                            | `http://mariadb.mirrors.ovh.net/MariaDB/repo`| no
 
 ## Examples
 
-To install '10.3' version:
+To install '10.11' version:
 
 ```ruby
-mariadb_repository 'MariaDB 10.3 Repository' do
-  version '10.3'
+mariadb_repository 'MariaDB 10.11 Repository' do
+  version '10.11'
 end
 ```

--- a/documentation/resource_mariadb_server_configuration.md
+++ b/documentation/resource_mariadb_server_configuration.md
@@ -8,7 +8,7 @@
 
 Name                            | Types             | Description                                                   | Default                                          | Required?
 ------------------------------- | ----------------- | ------------------------------------------------------------- | ------------------------------------------------ | ---------
-`version`                       | String            | Version of MariaDB installed                                  | `10.3`                                           | no
+`version`                       | String            | Version of MariaDB installed                                  | `10.11`                                          | no
 `cookbook`                      | String            |                                                               | `mariadb`                                        | no
 `mycnf_file`                    | String            |                                                               | `"#{conf_dir}my.cnf"` (1)                        | no
 `extra_configuration_directory` | String,           |                                                               | `ext_conf_dir` (2)                               | no
@@ -98,7 +98,7 @@ Name                            | Types             | Description               
 
 ```ruby
 mariadb_server_configuration 'MariaDB Server Configuration' do
-  version '10.3'
+  version '10.11'
   client_host 'localhost'
 end
 ```

--- a/documentation/resource_mariadb_server_install.md
+++ b/documentation/resource_mariadb_server_install.md
@@ -13,15 +13,10 @@ Name                            | Types             | Description               
 ------------------------------- | ----------------- | ------------------------------------------------------------- | ----------------------------------------- | ---------
 `version`                       | String            | Version of MariaDB to install                                 | `10.3`                                    | no
 `setup_repo`                    | Boolean           | Define if you want to add the MariaDB repository              | `true`                                    | no
-`mycnf_file`                    | String            |                                                               | `"#{conf_dir}/my.cnf"` (1)                | no
-`extra_configuration_directory` | String            |                                                               | `ext_conf_dir` (2)                        | no
-`external_pid_file`             | String            |                                                               | `default_pid_file` (3)                    | no
-`cookbook`                      | String            | The cookbook to look in for the template source               | `mariadb`                                 | yes
 `password`                      | String, nil       | Pass in a password, or have the cookbook generate one for you | `generate`                                | no
+`install_sleep`                 | Integer           | Number of seconds to sleep in between install commands        | `5`                                       | no
 
-(1) `conf_dir` is a helper method which return the main configuration directory based on OS flavor
-(2) `ext_conf_dir` is a helper method which return the extra configuration directory based on OS flavor
-(3) `default_pid_file` is a helper method which return the pid file name and path based on OS flavor
+(1) `default_pid_file` is a helper method which return the pid file name and path based on OS flavor
 
 ## Examples
 

--- a/documentation/resource_mariadb_server_install.md
+++ b/documentation/resource_mariadb_server_install.md
@@ -11,7 +11,7 @@ This resource installs mariadb server packages.
 
 Name                            | Types             | Description                                                   | Default                                   | Required?
 ------------------------------- | ----------------- | ------------------------------------------------------------- | ----------------------------------------- | ---------
-`version`                       | String            | Version of MariaDB to install                                 | `10.3`                                    | no
+`version`                       | String            | Version of MariaDB to install                                 | `10.11`                                   | no
 `setup_repo`                    | Boolean           | Define if you want to add the MariaDB repository              | `true`                                    | no
 `password`                      | String, nil       | Pass in a password, or have the cookbook generate one for you | `generate`                                | no
 `install_sleep`                 | Integer           | Number of seconds to sleep in between install commands        | `5`                                       | no
@@ -20,10 +20,10 @@ Name                            | Types             | Description               
 
 ## Examples
 
-To install '10.3' version:
+To install '10.11' version:
 
 ```ruby
 mariadb_server_install 'MariaDB Server install' do
-  version '10.3'
+  version '10.11'
 end
 ```

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -37,22 +37,9 @@ suites:
   - name: client_distro_install
     run_list:
       - recipe[test::client_distro_install]
-  - name: server_install_10.3
+  - name: server_install
     run_list:
       - recipe[test::server_install]
-    attributes:
-      mariadb_server_test_version: '10.3'
-    verifier:
-      inspec_tests:
-        - path: test/integration/server_install
-  - name: server_install_10.4
-    run_list:
-      - recipe[test::server_install]
-    attributes:
-      mariadb_server_test_version: '10.4'
-    verifier:
-      inspec_tests:
-        - path: test/integration/server_install
   - name: server_distro_install
     run_list:
       - recipe[test::server_distro_install]

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -257,7 +257,7 @@ module MariaDBCookbook
     def default_pid_file
       case node['platform_family']
       when 'rhel', 'fedora', 'amazon'
-        nil
+        '/run/mysqld/mysqld.pid'
       when 'debian'
         '/var/run/mysqld/mysqld.pid'
       end

--- a/resources/galera_configuration.rb
+++ b/resources/galera_configuration.rb
@@ -28,7 +28,7 @@ property :gcomm_address,                         [String, nil]
 property :innodb_flush_log_at_trx_commit,        Integer,        default: 2
 property :options,                               Hash,           default: {}
 property :server_id,                             Integer,        default: 100
-property :version,                               String,         default: '10.3'
+property :version,                               String,         default: '10.11'
 property :wsrep_node_address_interface,          [String, nil]
 property :wsrep_node_incoming_address_interface, String
 property :wsrep_node_port,                       [Integer, nil], default: nil

--- a/resources/replication.rb
+++ b/resources/replication.rb
@@ -20,7 +20,7 @@ unified_mode true
 include MariaDBCookbook::Helpers
 
 property :connection_name,             String,         name_property: true
-property :version,                     String,         default: '10.3'
+property :version,                     String,         default: '10.11'
 property :host,                        [String, nil],  default: 'localhost', desired_state: false
 property :port,                        [Integer, nil], default: 3306,        desired_state: false
 property :user,                        [String, nil],  default: 'root',      desired_state: false

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -18,7 +18,7 @@
 provides :mariadb_repository
 unified_mode true
 
-property :version,            String, default: '10.3'
+property :version,            String, default: '10.11'
 property :enable_mariadb_org, [true, false], default: true
 property :yum_gpg_key_uri,    String, default: 'https://yum.mariadb.org/RPM-GPG-KEY-MariaDB'
 property :apt_gpg_keyserver,  String, default: 'keyserver.ubuntu.com'

--- a/resources/server_configuration.rb
+++ b/resources/server_configuration.rb
@@ -20,7 +20,7 @@ unified_mode true
 
 include MariaDBCookbook::Helpers
 
-property :version,                        String,            default: '10.3'
+property :version,                        String,            default: '10.11'
 property :cookbook,                       String,            default: 'mariadb'
 property :mycnf_file,                     String,            default: lazy { "#{conf_dir}/my.cnf" }
 property :extra_configuration_directory,  String,            default: lazy { ext_conf_dir }

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -86,7 +86,7 @@ action :create do
     action :nothing
   end
 
-  pid_file = default_pid_file.nil? || '/var/run/mysqld/mysqld.pid'
+  pid_file = default_pid_file
   pid_dir = ::File.dirname(pid_file)
 
   # because some distros may not take care of the pid file location directory, we manage it ourselves

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -22,13 +22,7 @@ include MariaDBCookbook::Helpers
 
 property :version,           String,        default: '10.3'
 property :setup_repo,        [true, false], default: true
-property :mycnf_file,        String,        default: lazy { "#{conf_dir}/my.cnf" }
-property :extconf_directory, String,        default: lazy { ext_conf_dir }
-property :data_directory,    String,        default: lazy { data_dir }
-property :external_pid_file, String,        default: lazy { "/var/run/mysql/#{version}-main.pid" }
 property :password,          [String, nil], default: 'generate'
-property :port,              Integer,       default: 3306
-property :initdb_locale,     String,        default: 'UTF-8'
 property :install_sleep,     Integer,       default: 5, desired_state: false
 
 action :install do
@@ -92,7 +86,7 @@ action :create do
     action :nothing
   end
 
-  pid_file = default_pid_file.nil? ? '/var/run/mysqld/mysqld.pid' : default_pid_file
+  pid_file = default_pid_file.nil? || '/var/run/mysqld/mysqld.pid'
   pid_dir = ::File.dirname(pid_file)
 
   # because some distros may not take care of the pid file location directory, we manage it ourselves

--- a/spec/libraries/helper_spec.rb
+++ b/spec/libraries/helper_spec.rb
@@ -12,9 +12,9 @@ RSpec.describe MariaDBCookbook::Helpers do
       allow(subject).to receive(:[]).with('platform_family').and_return(platform_family)
     end
 
-    let(:version) { '10.3' }
+    let(:version) { '10.11' }
 
-    context 'with rhel family and MariaDB 10.3' do
+    context 'with rhel family and MariaDB 10.11' do
       let(:platform_family) { 'rhel' }
 
       it 'returns the correct path' do
@@ -22,7 +22,7 @@ RSpec.describe MariaDBCookbook::Helpers do
       end
     end
 
-    context 'with debian family and MariaDB 10.3' do
+    context 'with debian family and MariaDB 10.11' do
       let(:platform_family) { 'debian' }
 
       it 'returns the correct path' do

--- a/test/cookbooks/test/attributes/default.rb
+++ b/test/cookbooks/test/attributes/default.rb
@@ -1,2 +1,2 @@
 # Which default MariaDB version to use for testing (can be overridden in kitchen.yml)
-default['mariadb_server_test_version'] = '10.3'
+default['mariadb_server_test_version'] = '10.11'

--- a/test/integration/repository/controls/repository_spec.rb
+++ b/test/integration/repository/controls/repository_spec.rb
@@ -4,7 +4,7 @@ case os.family
 
 when 'redhat'
 
-  describe yum.repo('mariadb10.3') do
+  describe yum.repo('mariadb10.11') do
     it { should exist }
     it { should be_enabled }
   end
@@ -15,14 +15,14 @@ when 'debian'
 
   when 'debian'
 
-    describe apt('http://mariadb.mirrors.ovh.net/MariaDB/repo/10.3/debian') do
+    describe apt('http://mariadb.mirrors.ovh.net/MariaDB/repo/10.11/debian') do
       it { should exist }
       it { should be_enabled }
     end
 
   when 'ubuntu'
 
-    describe apt('http://mariadb.mirrors.ovh.net/MariaDB/repo/10.3/ubuntu') do
+    describe apt('http://mariadb.mirrors.ovh.net/MariaDB/repo/10.11/ubuntu') do
       it { should exist }
       it { should be_enabled }
     end


### PR DESCRIPTION
# Description

Remove unused properties from server_install resource

Removed the following properties:

- mycnf_file
- extconf_directory
- data_directory
- external_pid_file
- port
- initdb_locale

Updated documentation to reflect the changes.

Fix default pid file for rhel, fedora and amazon

Updated default mariadb version to 10.11 in all tests

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
