### PR TITLE
Remove unused properties from server_install resource

### DIFF
--- a/documentation/resource_mariadb_server_install.md
+++ b/documentation/resource_mariadb_server_install.md
@@ -13,15 +13,10 @@ Name                            | Types             | Description               
 ------------------------------- | ----------------- | ------------------------------------------------------------- | ----------------------------------------- | ---------
 `version`                       | String            | Version of MariaDB to install                                 | `10.3`                                    | no
 `setup_repo`                    | Boolean           | Define if you want to add the MariaDB repository              | `true`                                    | no
-`mycnf_file`                    | String            |                                                               | `"#{conf_dir}/my.cnf"` (1)                | no
-`extra_configuration_directory` | String            |                                                               | `ext_conf_dir` (2)                        | no
-`external_pid_file`             | String            |                                                               | `default_pid_file` (3)                    | no
-`cookbook`                      | String            | The cookbook to look in for the template source               | `mariadb`                                 | yes
 `password`                      | String, nil       | Pass in a password, or have the cookbook generate one for you | `generate`                                | no
+`install_sleep`                 | Integer           | Number of seconds to sleep in between install commands        | `5`                                       | no
 
-(1) `conf_dir` is a helper method which return the main configuration directory based on OS flavor
-(2) `ext_conf_dir` is a helper method which return the extra configuration directory based on OS flavor
-(3) `default_pid_file` is a helper method which return the pid file name and path based on OS flavor
+(1) `default_pid_file` is a helper method which return the pid file name and path based on OS flavor
 
 ## Examples
 

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -22,14 +22,8 @@ include MariaDBCookbook::Helpers
 
 property :version,           String,        default: '10.11'
 property :setup_repo,        [true, false], default: true
-property :mycnf_file,        String,        default: lazy { "#{conf_dir}/my.cnf" }
-property :extconf_directory, String,        default: lazy { ext_conf_dir }
-property :data_directory,    String,        default: lazy { data_dir }
-property :external_pid_file, String,        default: lazy { "/var/run/mysql/#{version}-main.pid" }
 property :password,          [String, nil], default: 'generate'
-property :port,              Integer,       default: 3306
-property :initdb_locale,     String,        default: 'UTF-8'
-property :install_sleep,     Integer,       default: 10, desired_state: false
+property :install_sleep,     Integer,       default: 5, desired_state: false
 
 action :install do
   node.run_state['mariadb'] ||= {}


### PR DESCRIPTION
# Description

Removed the following properties:

- mycnf_file
- extconf_directory
- data_directory
- external_pid_file
- port
- initdb_locale

Updated documentation to reflect the changes.

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [X] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
