### PR TITLE
Patch the ability to use SELinux with setup_repo disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-## 5.2.19 - *2023-04-18*
-
 Patched the ability to use SELinux with `setup_repo` disabled
 
 ## 5.2.18 - *2023-04-16*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-Patched the ability to use SELinux with `setup_repo` disabled
+- Patched the ability to use SELinux with `setup_repo` disabled
 
 ## 5.2.18 - *2023-04-16*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## 5.2.19 - *2023-04-18*
+
+Patched the ability to use SELinux with `setup_repo` disabled
+
 ## 5.2.18 - *2023-04-16*
 
 ## 5.2.17 - *2023-04-12*

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -306,6 +306,18 @@ module MariaDBCookbook
       end
     end
 
+    def default_selinux_module_path
+      if platform_family?('rhel', 'fedora', 'amazon')
+        '/usr/share/mariadb/policy/selinux'
+      else
+        if new_resource.setup_repo
+          '/usr/share/mariadb/policy/selinux'
+        else
+          '/usr/share/mysql/policy/selinux'
+        end
+      end
+    end
+
     # Get the query to use when sending a change password command, dependant on the version of the database.
     def mariadb_password_command(mariadb_root_password)
       cmd = shell_out('mysql --version')

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -309,12 +309,10 @@ module MariaDBCookbook
     def default_selinux_module_path
       if platform_family?('rhel', 'fedora', 'amazon')
         '/usr/share/mariadb/policy/selinux'
+      elsif new_resource.setup_repo
+        '/usr/share/mariadb/policy/selinux'
       else
-        if new_resource.setup_repo
-          '/usr/share/mariadb/policy/selinux'
-        else
-          '/usr/share/mysql/policy/selinux'
-        end
+        '/usr/share/mysql/policy/selinux'
       end
     end
 

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -47,8 +47,8 @@ action :install do
   # This should get automatically installed via the package, but in case it doesn't ensure it does here
   # https://mariadb.com/kb/en/selinux/
   selinux_module 'mariadb' do
-    base_dir '/usr/share/mysql/policy/selinux'
-    only_if { selinux_enabled? }
+    base_dir default_selinux_module_path
+    only_if { selinux_enabled? && Dir.exist?(default_selinux_module_path) }
     action :install
   end
 


### PR DESCRIPTION
# Description

This is an addendum to the #355 patch, where the path to the SELinux module is different, based on the version of MariaDB installed. SELinux was not tested during the initial development.

## Issues Resolved

* Developers who disable `setup_repo` on an SELinux-enabled node will no longer suffer from a converge error.

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
