### PR TITLE
[GH-370] - Fix yum repo url on redhat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Treat redhat like other members of the platform_family when generating yum repo url
+
 ## 5.3.2 - *2023-07-10*
 
 ## 5.3.1 - *2023-05-17*

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -259,7 +259,7 @@ module MariaDBCookbook
     def yum_repo_platform_string
       release = yum_releasever
       # Treat Alma and Rocky as RHEL
-      if platform?('almalinux', 'rocky', 'amazon')
+      if platform?('almalinux', 'rocky', 'amazon', 'redhat')
         "rhel/#{release}/$basearch"
       else
         "#{node['platform']}/#{release}/$basearch"


### PR DESCRIPTION
Treat redhat like other members of the platform_family to generate yum repo url

# Description

A valid yum repo url that is served by yum.mariadb.org is generated when trying to install mariadb on redhat

## Issues Resolved

GH-370

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
