### PR TITLE
Allow changing action behaviour of the package resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Allow changing action behaviour of the package resource (:install, :upgrade)
+
 ## 5.4.0 - *2023-08-19*
 
 - Treat redhat like other members of the platform_family when generating yum repo url

--- a/documentation/resource_mariadb_client_install.md
+++ b/documentation/resource_mariadb_client_install.md
@@ -10,8 +10,9 @@ This resource installs mariadb client packages.
 
 Name                | Types             | Description                                                   | Default                                   | Required?
 ------------------- | ----------------- | ------------------------------------------------------------- | ----------------------------------------- | ---------
-`version`           | String            | Version of MariaDB to install                                 | `10.3`                                    | no
+`version`           | String            | Version of MariaDB to install                                 | `10.11`                                   | no
 `setup_repo`        | Boolean           | Define if you want to add the MariaDB repository              | `true`                                    | no
+`package_action`    | :install, :upgrade| Package action behaviour                                      | `:install`                                | no
 
 ### Examples
 

--- a/documentation/resource_mariadb_server_install.md
+++ b/documentation/resource_mariadb_server_install.md
@@ -11,10 +11,11 @@ This resource installs mariadb server packages.
 
 Name                            | Types             | Description                                                   | Default                                   | Required?
 ------------------------------- | ----------------- | ------------------------------------------------------------- | ----------------------------------------- | ---------
-`version`                       | String            | Version of MariaDB to install                                 | `10.3`                                    | no
+`version`                       | String            | Version of MariaDB to install                                 | `10.11`                                   | no
 `setup_repo`                    | Boolean           | Define if you want to add the MariaDB repository              | `true`                                    | no
 `password`                      | String, nil       | Pass in a password, or have the cookbook generate one for you | `generate`                                | no
 `install_sleep`                 | Integer           | Number of seconds to sleep in between install commands        | `5`                                       | no
+`package_action`                | :install, :upgrade| Package action behaviour                                      | `:install`                                | no
 
 (1) `default_pid_file` is a helper method which return the pid file name and path based on OS flavor
 

--- a/resources/client_install.rb
+++ b/resources/client_install.rb
@@ -18,8 +18,9 @@
 provides :mariadb_client_install
 unified_mode true
 
-property :version,    String, default: '10.11'
-property :setup_repo, [true, false], default: true
+property :version,        String, default: '10.11'
+property :setup_repo,     [true, false], default: true
+property :package_action, [:install, :upgrade], default: :install
 
 action :install do
   mariadb_repository 'Add mariadb.org repository' do
@@ -27,7 +28,9 @@ action :install do
     only_if { new_resource.setup_repo }
   end
 
-  package client_pkg_name
+  package client_pkg_name do
+    action new_resource.package_action
+  end
 end
 
 action_class do

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -20,18 +20,22 @@ unified_mode true
 
 include MariaDBCookbook::Helpers
 
-property :version,           String,        default: '10.11'
-property :setup_repo,        [true, false], default: true
-property :password,          [String, nil], default: 'generate'
-property :install_sleep,     Integer,       default: 5, desired_state: false
+property :version,           String,               default: '10.11'
+property :setup_repo,        [true, false],        default: true
+property :password,          [String, nil],        default: 'generate'
+property :install_sleep,     Integer,              default: 5, desired_state: false
+property :package_action,    [:install, :upgrade], default: :install
 
 action :install do
   mariadb_client_install 'Install MariaDB Client' do
     version new_resource.version
     setup_repo new_resource.setup_repo
+    package_action new_resource.package_action
   end
 
-  package server_pkg_name
+  package server_pkg_name do
+    action new_resource.package_action
+  end
 
   selinux_install 'mariadb' if selinux_enabled?
 


### PR DESCRIPTION
# Description

In order to upgrade a package to the latest version, allow passing an action via the property `package_action` to the resource `mariadb_server_install` and `mariadb_client_install`

## Testing
I've tested it on the following platforms:
* Debian-10
* Debian-11
* Debian-12
* Ubuntu-22.04

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
