### PR TITLE
[#382] Update `myisam_recover` deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Resource: `mariadb_server_configuration`:
+  - Property `mysqld_myisam_recover` -- renamed to --> `mysqld_myisam_recover_options`
+
 ## 5.5.5 - *2024-07-15*
 
 Standardise files with files in sous-chefs/repo-management

--- a/documentation/resource_mariadb_server_configuration.md
+++ b/documentation/resource_mariadb_server_configuration.md
@@ -42,7 +42,7 @@ Name                            | Types             | Description               
 `mysqld_bulk_insert_buffer_size`| String            |                                                               | `16M`                                            | no
 `mysqld_tmp_table_size`         | String            |                                                               | `32M`                                            | no
 `mysqld_max_heap_table_size`    | String            |                                                               | `32M`                                            | no
-`mysqld_myisam_recover`         | String            |                                                               | `BACKUP`                                         | no
+`mysqld_myisam_recover_options` | String            |                                                               | `BACKUP`                                         | no
 `mysqld_key_buffer_size`        | String            |                                                               | `128M`                                           | no
 `mysqld_open_files_limit`       | Integer, nil      |                                                               | `nil`                                            | no
 `mysqld_table_open_cache`       | Integer           |                                                               | `400`                                            | no

--- a/resources/server_configuration.rb
+++ b/resources/server_configuration.rb
@@ -54,7 +54,7 @@ property :mysqld_sort_buffer_size,        String,            default: '4M'
 property :mysqld_bulk_insert_buffer_size, String,            default: '16M'
 property :mysqld_tmp_table_size,          String,            default: '32M'
 property :mysqld_max_heap_table_size,     String,            default: '32M'
-property :mysqld_myisam_recover,          String,            default: 'BACKUP'
+property :mysqld_myisam_recover_options,  String,            default: 'BACKUP'
 property :mysqld_key_buffer_size,         String,            default: '128M'
 property :mysqld_open_files_limit,        [Integer, nil],    default: nil
 property :mysqld_table_open_cache,        Integer,           default: 400
@@ -100,6 +100,12 @@ property :replication_expire_logs_days,   Integer,           default: 10
 property :replication_max_binlog_size,    String,            default: '100M'
 property :replication_options,            Hash,              default: {}
 
+deprecated_property_alias(
+  'mysqld_myisam_recover',
+  'mysqld_myisam_recover_options',
+  'Please `mysqld_myisam_recover_options` as `mysqld_myisam_recover` and its associated mariadb setting is deprecated'
+)
+
 action :modify do
   template new_resource.mycnf_file do
     source 'my.cnf.erb'
@@ -137,7 +143,7 @@ action :modify do
               mysqld_bulk_insert_buffer_size: new_resource.mysqld_bulk_insert_buffer_size,
               mysqld_tmp_table_size: new_resource.mysqld_tmp_table_size,
               mysqld_max_heap_table_size: new_resource.mysqld_max_heap_table_size,
-              mysqld_myisam_recover: new_resource.mysqld_myisam_recover,
+              mysqld_myisam_recover_options: new_resource.mysqld_myisam_recover_options,
               mysqld_key_buffer_size: new_resource.mysqld_key_buffer_size,
               mysqld_open_files_limit: new_resource.mysqld_open_files_limit,
               mysqld_table_open_cache: new_resource.mysqld_table_open_cache,

--- a/templates/default/my.cnf.erb
+++ b/templates/default/my.cnf.erb
@@ -19,35 +19,35 @@
 # Remember to edit /etc/mysql/debian.cnf when changing the socket location.
 <% end -%>
 [client]
-port		= <%= @client_port %>
-socket		= <%= @client_socket %>
+port   = <%= @client_port %>
+socket = <%= @client_socket %>
 <% unless @client_host.nil? -%>
-host		= <%= @client_host %>
+host   = <%= @client_host %>
 <% end -%>
-<% @client_options.each { |key, value| -%>
+<% @client_options.each do |key, value| -%>
 <%= key %> = <%= value %>
-<%   } -%>
+<% end -%>
 
 # This was formally known as [safe_mysqld]. Both versions are currently parsed.
 [mysqld_safe]
-socket		= <%= @mysqld_safe_socket %>
-nice		= 0
-<% @mysqld_safe_options.each { |key, value| -%>
+socket = <%= @mysqld_safe_socket %>
+nice   = 0
+<% @mysqld_safe_options.each do |key, value| -%>
 <%= key %> = <%= value %>
-<%   } -%>
+<% end -%>
 
 [mysqld]
-user		= <%= @mysqld_user %>
+user            = <%= @mysqld_user %>
 <% unless @mysqld_pid_file.nil? -%>
-pid-file	= <%= @mysqld_pid_file %>
+pid-file        = <%= @mysqld_pid_file %>
 <% end -%>
-socket		= <%= @mysqld_socket %>
-port		= <%= @mysqld_port %>
-basedir		= <%= @mysqld_basedir %>
-datadir		= <%= @mysqld_datadir %>
-tmpdir		= <%= @mysqld_tmpdir %>
-lc_messages_dir	= <%= @mysqld_lc_messages_dir %>
-lc_messages	= <%= @mysqld_lc_messages %>
+socket          = <%= @mysqld_socket %>
+port            = <%= @mysqld_port %>
+basedir         = <%= @mysqld_basedir %>
+datadir         = <%= @mysqld_datadir %>
+tmpdir          = <%= @mysqld_tmpdir %>
+lc_messages_dir = <%= @mysqld_lc_messages_dir %>
+lc_messages     = <%= @mysqld_lc_messages %>
 <% if @mysqld_skip_external_locking -%>
 skip-external-locking
 <% end -%>
@@ -61,49 +61,49 @@ skip-name-resolve
 # Instead of skip-networking the default is now to listen only on
 # localhost which is more compatible and is not less secure.
 <% unless @mysqld_bind_address.nil? or @mysqld_bind_address.empty? -%>
-bind-address		= <%= @mysqld_bind_address %>
+bind-address    = <%= @mysqld_bind_address %>
 <% end -%>
 #
 # * Fine Tuning
 #
-max_connections		= <%= @mysqld_max_connections %>
+max_connections         = <%= @mysqld_max_connections %>
 <% unless @mysqld_max_statement_time.nil? -%>
-max_statement_time  = <%= @mysqld_max_statement_time %>
+max_statement_time      = <%= @mysqld_max_statement_time %>
 <% end -%>
-connect_timeout		= <%= @mysqld_connect_timeout %>
-wait_timeout		= <%= @mysqld_wait_timeout %>
-max_allowed_packet	= <%= @mysqld_max_allowed_packet %>
+connect_timeout         = <%= @mysqld_connect_timeout %>
+wait_timeout            = <%= @mysqld_wait_timeout %>
+max_allowed_packet      = <%= @mysqld_max_allowed_packet %>
 thread_cache_size       = <%= @mysqld_thread_cache_size %>
-sort_buffer_size	= <%= @mysqld_sort_buffer_size %>
-bulk_insert_buffer_size	= <%= @mysqld_bulk_insert_buffer_size %>
-tmp_table_size		= <%= @mysqld_tmp_table_size %>
-max_heap_table_size	= <%= @mysqld_max_heap_table_size %>
+sort_buffer_size        = <%= @mysqld_sort_buffer_size %>
+bulk_insert_buffer_size = <%= @mysqld_bulk_insert_buffer_size %>
+tmp_table_size          = <%= @mysqld_tmp_table_size %>
+max_heap_table_size     = <%= @mysqld_max_heap_table_size %>
 #
 # * MyISAM
 #
 # This replaces the startup script and checks MyISAM tables if needed
 # the first time they are touched. On error, make copy and try a repair.
-myisam_recover          = <%= @mysqld_myisam_recover  %>
-key_buffer_size		= <%= @mysqld_key_buffer_size %>
+myisam_recover_options  = <%= @mysqld_myisam_recover_options  %>
+key_buffer_size         = <%= @mysqld_key_buffer_size %>
 <% unless @mysqld_open_files_limit.nil? -%>
-open-files-limit	= <%= @mysqld_open_files_limit %>
+open-files-limit        = <%= @mysqld_open_files_limit %>
 <% end -%>
-table_open_cache	= <%= @mysqld_table_open_cache %>
-myisam_sort_buffer_size	= <%= @mysqld_myisam_sort_buffer_size %>
-concurrent_insert	= <%= @mysqld_concurrent_insert %>
-read_buffer_size	= <%= @mysqld_read_buffer_size %>
-read_rnd_buffer_size	= <%= @mysqld_read_rnd_buffer_size %>
+table_open_cache        = <%= @mysqld_table_open_cache %>
+myisam_sort_buffer_size = <%= @mysqld_myisam_sort_buffer_size %>
+concurrent_insert       = <%= @mysqld_concurrent_insert %>
+read_buffer_size        = <%= @mysqld_read_buffer_size %>
+read_rnd_buffer_size    = <%= @mysqld_read_rnd_buffer_size %>
 #
 # * Query Cache Configuration
 #
 # Cache only tiny result sets, so we can fit more in the query cache.
-query_cache_limit		= <%= @mysqld_query_cache_limit %>
-query_cache_size		= <%= @mysqld_query_cache_size %>
+query_cache_limit = <%= @mysqld_query_cache_limit %>
+query_cache_size  = <%= @mysqld_query_cache_size %>
 # for more write intensive setups, set to DEMAND or OFF
 <% if @mysqld_query_cache_type.nil? -%>
-#query_cache_type		= DEMAND
+#query_cache_type = DEMAND
 <% else -%>
-query_cache_type                = <%= @mysqld_query_cache_type %>
+query_cache_type  = <%= @mysqld_query_cache_type %>
 <% end -%>
 #
 # * Logging and Replication
@@ -111,21 +111,21 @@ query_cache_type                = <%= @mysqld_query_cache_type %>
 # Both location gets rotated by the cronjob.
 # Be aware that this log type is a performance killer.
 # As of 5.1 you can enable the log at runtime!
-general_log_file        = <%= @mysqld_general_log_file %>
-general_log             = <%= @mysqld_general_log %>
+general_log_file    = <%= @mysqld_general_log_file %>
+general_log         = <%= @mysqld_general_log %>
 #
 # Error logging goes to syslog due to /etc/mysql/conf.d/mysqld_safe_syslog.cnf.
 #
 # we do want to know about network errors and such
-log_warnings		= <%= @mysqld_log_warnings %>
+log_warnings        = <%= @mysqld_log_warnings %>
 #
 # Enable the slow query log to see queries with especially long duration
 #slow_query_log[={0|1}]
-slow_query_log          = <%= @mysqld_slow_query_log %>
-slow_query_log_file	= <%= @mysqld_slow_query_log_file %>
-long_query_time         = <%= @mysqld_long_query_time %>
-log_slow_rate_limit	= <%= @mysqld_log_slow_rate_limit %>
-log_slow_verbosity	= <%= @mysqld_log_slow_verbosity %>
+slow_query_log      = <%= @mysqld_slow_query_log %>
+slow_query_log_file = <%= @mysqld_slow_query_log_file %>
+long_query_time     = <%= @mysqld_long_query_time %>
+log_slow_rate_limit = <%= @mysqld_log_slow_rate_limit %>
+log_slow_verbosity  = <%= @mysqld_log_slow_verbosity %>
 # Logging output type
 log_output = <%= @mysqld_log_output %>
 
@@ -135,23 +135,23 @@ log_output = <%= @mysqld_log_output %>
 # The following can be used as easy to replay backup logs or for replication.
 # note: if you are setting up a replication slave, see README.Debian about
 #       other settings you may need to change.
-#report_host		= master1
+#report_host    = master1
 #auto_increment_increment = 2
-#auto_increment_offset	= 1
+#auto_increment_offset  = 1
 # not fab for performance, but safer
-#sync_binlog		= 1
+#sync_binlog    = 1
 # slaves
-#relay_log		= /var/log/mysql/relay-bin
-#relay_log_index	= /var/log/mysql/relay-bin.index
-#relay_log_info_file	= /var/log/mysql/relay-bin.info
+#relay_log    = /var/log/mysql/relay-bin
+#relay_log_index  = /var/log/mysql/relay-bin.index
+#relay_log_info_file  = /var/log/mysql/relay-bin.info
 #log_slave_updates
 #read_only
 #
 # If applications support it, this stricter sql_mode prevents some
 # mistakes like inserting invalid dates etc.
-#sql_mode		= NO_ENGINE_SUBSTITUTION,TRADITIONAL
+#sql_mode    = NO_ENGINE_SUBSTITUTION,TRADITIONAL
 
-default_storage_engine	= <%= @mysqld_default_storage_engine %>
+default_storage_engine = <%= @mysqld_default_storage_engine %>
 
 #
 # * Security Features
@@ -165,9 +165,9 @@ default_storage_engine	= <%= @mysqld_default_storage_engine %>
 # ssl-cert=/etc/mysql/server-cert.pem
 # ssl-key=/etc/mysql/server-key.pem
 
-<% @mysqld_options.each { |key, value| -%>
+<% @mysqld_options.each do |key, value| -%>
 <%= key %> = <%= value %>
-<% } -%>
+<% end -%>
 
 [mysqldump]
 <% if @mysqldump_quick -%>
@@ -176,13 +176,13 @@ quick
 <% if @mysqldump_quote_names -%>
 quote-names
 <% end -%>
-max_allowed_packet	= <%= @mysqldump_max_allowed_packet %>
+max_allowed_packet = <%= @mysqldump_max_allowed_packet %>
 
 [mysql]
-#no-auto-rehash	# faster start of mysql but no tab completition
+#no-auto-rehash  # faster start of mysql but no tab completition
 
 [isamchk]
-key_buffer		= <%= @isamchk_key_buffer %>
+key_buffer = <%= @isamchk_key_buffer %>
 
 #
 # * IMPORTANT: Additional settings that can override those from this file!


### PR DESCRIPTION
- `myisam_recover` has been deprecated for sometime now.
- Use `myisam_recover_options` instead.

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
