### PR TITLE
Update supported platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,89 +22,37 @@ jobs:
       matrix:
         os:
           - almalinux-8
-          # - amazonlinux-2023
-          - centos-7
-          - centos-stream-8
-          - debian-10
+          - almalinux-9
+          - centos-stream-9
           - debian-11
+          - debian-12
           - rockylinux-8
-          - ubuntu-1804
+          - rockylinux-9
           - ubuntu-2004
-          # Latest fedora (38 at time of writing) does not have any mariadb packages yet
-          # - fedora-latest
+          - ubuntu-2204
+          - ubuntu-2404
         suite:
           - "repository"
+          - "repository-10"
           - "client-install"
+          - "client-install-10"
           - "client-distro-install"
           - "server-install"
-          - "server-install-1011"
+          - "server-install-10"
           - "server-distro-install"
           - "configuration"
           - "server-configuration"
-          - "server-configuration-1011"
+          - "server-configuration-10"
           - "resources"
-          - "resources-1011"
+          - "resources-10"
           - "replication"
-          - "replication-1011"
+          - "replication-10"
           - "datadir"
-          - "datadir-1011"
+          - "datadir-10"
           - "port"
-          - "port-1011"
+          - "port-10"
           - "galera-configuration"
-          - "galera-configuration-1011"
-        exclude:
-          - os: ubuntu-1804
-            suite: "server-install-1011"
-          - os: ubuntu-1804
-            suite: "server-configuration-1011"
-          - os: ubuntu-1804
-            suite: "resources-1011"
-          - os: ubuntu-1804
-            suite: "replication-1011"
-          - os: ubuntu-1804
-            suite: "datadir-1011"
-          - os: ubuntu-1804
-            suite: "port-1011"
-          - os: ubuntu-1804
-            suite: "galera-configuration-1011"
-          - os: centos-7
-            suite: "server-install-1011"
-          - os: centos-7
-            suite: "server-configuration-1011"
-          - os: centos-7
-            suite: "resources-1011"
-          - os: centos-7
-            suite: "replication-1011"
-          - os: centos-7
-            suite: "datadir-1011"
-          - os: centos-7
-            suite: "port-1011"
-          - os: centos-7
-            suite: "galera-configuration-1011"
-          - os: debian-11
-            suite: "repository"
-          - os: debian-11
-            suite: "client-install"
-          - os: debian-11
-            suite: "client-distro-install"
-          - os: debian-11
-            suite: "server-install"
-          - os: debian-11
-            suite: "server-distro-install"
-          - os: debian-11
-            suite: "configuration"
-          - os: debian-11
-            suite: "server-configuration"
-          - os: debian-11
-            suite: "resources"
-          - os: debian-11
-            suite: "replication"
-          - os: debian-11
-            suite: "datadir"
-          - os: debian-11
-            suite: "port"
-          - os: debian-11
-            suite: "galera-configuration"
+          - "galera-configuration-10"
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Update supported platforms
+- Default to MariaDB 11.6 from 10.3
+- Update URI for yum and apt repos and GPG keys
+- Remove support for AmazonLinux
+
 ## 5.5.5 - *2024-07-15*
 
-Standardise files with files in sous-chefs/repo-management
-
-Standardise files with files in sous-chefs/repo-management
-
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
 
 ## 5.5.4 - *2024-05-06*
 

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -17,36 +17,46 @@ verifier:
 
 platforms:
   - name: almalinux-8
-  # - name: amazonlinux-2023
-  - name: debian-10
+  - name: almalinux-9
+  - name: centos-stream-9
   - name: debian-11
-  - name: centos-7
-  - name: centos-stream-8
-  # - name: fedora-latest
-  - name: ubuntu-18.04
-  - name: ubuntu-20.04
+  - name: debian-12
   - name: rockylinux-8
+  - name: rockylinux-9
+  - name: ubuntu-20.04
+  - name: ubuntu-22.04
+  - name: ubuntu-24.04
 
 suites:
   - name: repository
     run_list:
       - recipe[test::repository]
-    excludes:
-      - debian-11
+  - name: repository-10
+    run_list:
+      - recipe[test::repository]
+    attributes:
+      mariadb_server_test_version: '10.11'
+    verifier:
+      inspec_tests:
+        - path: test/integration/repository
   - name: client_install
     run_list:
       - recipe[test::client_install]
-    excludes:
-      - debian-11
+  - name: client_install-10
+    run_list:
+      - recipe[test::client_install]
+    attributes:
+      mariadb_server_test_version: '10.11'
+    verifier:
+      inspec_tests:
+        - path: test/integration/client_install
   - name: client_distro_install
     run_list:
       - recipe[test::client_distro_install]
   - name: server_install
     run_list:
       - recipe[test::server_install]
-    excludes:
-      - debian-11
-  - name: server_install_10.11
+  - name: server_install-10
     run_list:
       - recipe[test::server_install]
     attributes:
@@ -54,23 +64,16 @@ suites:
     verifier:
       inspec_tests:
         - path: test/integration/server_install
-    excludes:
-      - ubuntu-18.04
-      - centos-7
   - name: server_distro_install
     run_list:
       - recipe[test::server_distro_install]
   - name: configuration
     run_list:
       - recipe[test::configuration]
-    excludes:
-      - debian-11
   - name: server_configuration
     run_list:
       - recipe[test::server_configuration]
-    excludes:
-      - debian-11
-  - name: server_configuration_10.11
+  - name: server_configuration_10
     run_list:
       - recipe[test::server_configuration]
     attributes:
@@ -78,15 +81,10 @@ suites:
     verifier:
       inspec_tests:
         - path: test/integration/server_configuration
-    excludes:
-      - ubuntu-18.04
-      - centos-7
   - name: resources
     run_list:
       - recipe[test::user_database]
-    excludes:
-      - debian-11
-  - name: resources_10.11
+  - name: resources_10
     run_list:
       - recipe[test::user_database]
     attributes:
@@ -94,15 +92,10 @@ suites:
     verifier:
       inspec_tests:
         - path: test/integration/resources
-    excludes:
-      - ubuntu-18.04
-      - centos-7
   - name: replication
     run_list:
       - recipe[test::replication]
-    excludes:
-      - debian-11
-  - name: replication_10.11
+  - name: replication_10
     run_list:
       - recipe[test::replication]
     attributes:
@@ -110,43 +103,28 @@ suites:
     verifier:
       inspec_tests:
         - path: test/integration/replication
-    excludes:
-      - ubuntu-18.04
-      - centos-7
   - name: datadir
     run_list:
       - recipe[test::datadir]
-    excludes:
-      - debian-11
-  - name: datadir_10.11
+  - name: datadir_10
     run_list:
       - recipe[test::datadir]
     verifier:
       inspec_tests:
         - path: test/integration/datadir
-    excludes:
-      - ubuntu-18.04
-      - centos-7
   - name: port
     run_list:
       - recipe[test::port]
-    excludes:
-      - debian-11
-  - name: port_10.11
+  - name: port_10
     run_list:
       - recipe[test::port]
     verifier:
       inspec_tests:
         - path: test/integration/port
-    excludes:
-      - ubuntu-18.04
-      - centos-7
   - name: galera_configuration
     run_list:
       - recipe[test::galera_configuration]
-    excludes:
-      - debian-11
-  - name: galera_configuration_10.11
+  - name: galera_configuration_10
     run_list:
       - recipe[test::galera_configuration]
     attributes:
@@ -154,6 +132,3 @@ suites:
     verifier:
       inspec_tests:
         - path: test/integration/galera_configuration
-    excludes:
-      - ubuntu-18.04
-      - centos-7

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -222,7 +222,7 @@ module MariaDBCookbook
     end
 
     def mariadbbackup_pkg_name
-      if platform_family?('rhel', 'fedora', 'amazon')
+      if platform_family?('rhel', 'fedora')
         'MariaDB-backup'
       else
         'mariadb-backup'
@@ -257,18 +257,12 @@ module MariaDBCookbook
 
     # build the platform string that makes up the final component of the yum repo URL
     def yum_repo_platform_string
-      release = yum_releasever
       # Treat Alma and Rocky as RHEL
-      if platform?('almalinux', 'rocky', 'amazon', 'redhat')
-        "rhel/#{release}/$basearch"
+      if platform?('almalinux', 'rocky', 'redhat')
+        'rhel/$releasever/$basearch'
       else
-        "#{node['platform']}/#{release}/$basearch"
+        "#{node['platform']}/$releasever/$basearch"
       end
-    end
-
-    # on amazon use the RHEL 7 packages. Otherwise use the releasever yum variable
-    def yum_releasever
-      platform?('amazon') ? '7' : '$releasever'
     end
 
     def default_socket
@@ -292,7 +286,7 @@ module MariaDBCookbook
 
     def default_mysqld_path
       case node['platform_family']
-      when 'rhel', 'fedora', 'amazon'
+      when 'rhel', 'fedora'
         if new_resource.setup_repo
           '/usr/sbin/mysqld'
         else
@@ -304,7 +298,7 @@ module MariaDBCookbook
     end
 
     def default_selinux_module_path
-      if platform_family?('rhel', 'fedora', 'amazon')
+      if platform_family?('rhel', 'fedora')
         '/usr/share/mariadb/policy/selinux'
       elsif new_resource.setup_repo
         '/usr/share/mariadb/policy/selinux'

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -18,9 +18,9 @@
 provides :mariadb_repository
 unified_mode true
 
-property :version,            String, default: '10.3'
+property :version,            String, default: '11.6'
 property :enable_mariadb_org, [true, false], default: true
-property :yum_gpg_key_uri,    String, default: 'https://yum.mariadb.org/RPM-GPG-KEY-MariaDB'
+property :yum_gpg_key_uri,    String, default: 'https://mirror.mariadb.org/yum/RPM-GPG-KEY-MariaDB'
 property :apt_gpg_keyserver,  String, default: 'keyserver.ubuntu.com'
 property :apt_gpg_key,        String, default: lazy {
   if node['lsb']['codename'] == 'buster' || node['lsb']['codename'] == 'buster/sid'
@@ -32,12 +32,12 @@ property :apt_gpg_key,        String, default: lazy {
   end
 }
 property :apt_key_proxy,      [String, false], default: false
-property :apt_repository_uri, String, default: 'http://mariadb.mirrors.ovh.net/MariaDB/repo'
+property :apt_repository_uri, String, default: 'https://mirror.mariadb.org/repo'
 
 action :add do
   case node['platform_family']
 
-  when 'rhel', 'fedora', 'amazon'
+  when 'rhel', 'fedora'
     remote_file "/etc/pki/rpm-gpg/RPM-GPG-KEY-MariaDB-#{new_resource.version}" do
       source new_resource.yum_gpg_key_uri
     end
@@ -52,7 +52,7 @@ action :add do
     yum_repository "MariaDB #{new_resource.version}" do
       repositoryid "mariadb#{new_resource.version}"
       description "MariaDB.org #{new_resource.version}"
-      baseurl     yum_repo_url('http://yum.mariadb.org')
+      baseurl     yum_repo_url('https://mirror.mariadb.org/yum')
       enabled     new_resource.enable_mariadb_org
       options     opts
       gpgcheck    true

--- a/test/cookbooks/test/attributes/default.rb
+++ b/test/cookbooks/test/attributes/default.rb
@@ -1,2 +1,2 @@
 # Which default MariaDB version to use for testing (can be overridden in kitchen.yml)
-default['mariadb_server_test_version'] = '10.3'
+default['mariadb_server_test_version'] = '11.6'

--- a/test/integration/client_install/controls/client_install_spec.rb
+++ b/test/integration/client_install/controls/client_install_spec.rb
@@ -5,6 +5,11 @@ end
 version = file('/tmp/mariadb_version').content
 
 describe command('/usr/bin/mysql -V') do
-  its('stdout') { should match(%r{\/usr\/bin\/mysql  Ver 15\.1 Distrib #{version}\.\d+-MariaDB}) }
+  case version.to_i
+  when 11
+    its('stdout') { should match(/mysql from #{version}\.\d+-MariaDB, client 15.2/) }
+  else
+    its('stdout') { should match(%r{\/usr\/bin\/mysql  Ver 15\.1 Distrib #{version}\.\d+-MariaDB}) }
+  end
   its('exit_status') { should eq 0 }
 end

--- a/test/integration/configuration/controls/configuration_spec.rb
+++ b/test/integration/configuration/controls/configuration_spec.rb
@@ -3,7 +3,7 @@
 # includedir = '/etc/mysql/conf.d'
 extra_config_file = '/etc/mysql/conf.d/extra_innodb.cnf'
 case os[:family]
-when 'centos', 'redhat', 'amazon', 'fedora'
+when 'centos', 'redhat', 'fedora'
   # includedir = '/etc/my.cnf.d'
   extra_config_file = '/etc/my.cnf.d/extra_innodb.cnf'
 end

--- a/test/integration/repository/controls/repository_spec.rb
+++ b/test/integration/repository/controls/repository_spec.rb
@@ -3,7 +3,7 @@
 version = file('/tmp/mariadb_version').content
 
 if os.debian?
-  describe apt("http://mariadb.mirrors.ovh.net/MariaDB/repo/#{version}/#{os.name}") do
+  describe apt("https://mirror.mariadb.org/repo/#{version}/#{os.name}") do
     it { should exist }
     it { should be_enabled }
   end


### PR DESCRIPTION
- Default to MariaDB 11.6 from 10.3
- Update URI for yum and apt repos and GPG keys

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
