### PR TITLE
Switch default from 11.6 to 11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+- Switch default from 11.6 to 11.4
+  - 11.6 is a development release, 11.4 is the LTS release
+
 ## 6.1.1 - *2024-11-18*
 
-Standardise files with files in sous-chefs/repo-management
-
-Standardise files with files in sous-chefs/repo-management
+- Standardise files with files in sous-chefs/repo-management
 
 ## 6.1.0 - *2024-11-15*
 

--- a/resources/client_install.rb
+++ b/resources/client_install.rb
@@ -18,7 +18,7 @@
 provides :mariadb_client_install
 unified_mode true
 
-property :version,        String, default: '10.11'
+property :version,        String, default: '11.4'
 property :setup_repo,     [true, false], default: true
 property :package_action, [:install, :upgrade], default: :install
 

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -18,7 +18,7 @@
 provides :mariadb_repository
 unified_mode true
 
-property :version,            String, default: '11.6'
+property :version,            String, default: '11.4'
 property :enable_mariadb_org, [true, false], default: true
 property :yum_gpg_key_uri,    String, default: 'https://mirror.mariadb.org/yum/RPM-GPG-KEY-MariaDB'
 property :apt_gpg_keyserver,  String, default: 'keyserver.ubuntu.com'

--- a/resources/server_install.rb
+++ b/resources/server_install.rb
@@ -20,7 +20,7 @@ unified_mode true
 
 include MariaDBCookbook::Helpers
 
-property :version,           String,               default: '10.11'
+property :version,           String,               default: '11.4'
 property :setup_repo,        [true, false],        default: true
 property :password,          [String, nil],        default: 'generate'
 property :install_sleep,     Integer,              default: 5, desired_state: false

--- a/test/cookbooks/test/attributes/default.rb
+++ b/test/cookbooks/test/attributes/default.rb
@@ -1,2 +1,2 @@
 # Which default MariaDB version to use for testing (can be overridden in kitchen.yml)
-default['mariadb_server_test_version'] = '11.6'
+default['mariadb_server_test_version'] = '11.4'


### PR DESCRIPTION
11.6 is a development release, 11.4 is the LTS release

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
