### PR TITLE
fix: migrate to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
           - almalinux-8
           - almalinux-9
           - centos-stream-9
-          - debian-11
           - debian-12
+          - debian-13
           - rockylinux-8
           - rockylinux-9
           - ubuntu-2004

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
         uses: actions/checkout@v7
       - name: Install Chef
         uses: actionshub/chef-install@6.0.0
+      - name: Install cookbooks
+        run: chef install Policyfile.rb
       - name: Disable apparmor for mysqld
         run: |
           set -x

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,7 @@ jobs:
           - "galera-configuration"
           - "galera-configuration-10"
       fail-fast: false
+      max-parallel: 8
 
     steps:
       - name: Check out code

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Install Chef
         uses: actionshub/chef-install@main
       - name: Install cookbooks
-        run: berks install
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,13 +36,11 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/
 .coverage/
 .zero-knife.rb
-Policyfile.lock.json
 
 # vagrant stuff
 .vagrant/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# AGENTS.md
+
+## Policyfile migration notes
+
+* This cookbook uses `Policyfile.rb` for local and CI dependency resolution. Keep
+  test cookbook recipes available as named run lists so Kitchen suites preserve
+  the old Berkshelf run-list behavior.
+* `yum-epel` is sourced from GitHub because Supermarket resolution can return
+  HTTP 403 during CI solves. The current `sous-chefs/yum-epel` cookbook is
+  resource-first and does not ship `recipes/default.rb`; use the `yum_epel`
+  resource in test recipes instead of `include_recipe 'yum-epel'`.
+* MariaDB package suites use `mirror.mariadb.org`. The mirror redirector can
+  return transient metadata or RPM download failures when the large integration
+  matrix fans out too aggressively, especially across `10.11` RHEL-family jobs.
+  Keep CI matrix parallelism capped rather than removing otherwise valid
+  platform coverage for transient mirror errors.

--- a/Berksfile
+++ b/Berksfile
@@ -1,7 +1,0 @@
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: './test/cookbooks/test'
-end

--- a/Policyfile.lock.json
+++ b/Policyfile.lock.json
@@ -1,5 +1,5 @@
 {
-  "revision_id": "09c45a9f6275e0277175a036f6ba4756133489ad68affd2a2d2ec996b7ec1db1",
+  "revision_id": "32ed6f58ef8838c95dfa882c924a5b94cb72ec52ec79775c188e535b53b5f0bf",
   "name": "mariadb",
   "run_list": [
     "recipe[test::repository]"
@@ -48,14 +48,14 @@
   "cookbook_locks": {
     "mariadb": {
       "version": "6.2.3",
-      "identifier": "1adeb3642d452ef5d7c1cc59c054a6e155bbffbc",
-      "dotted_decimal_identifier": "7563211455677742.69198596651204692.183486736236476",
+      "identifier": "82f38c94ec8f13111f0651f32ebf9a299bf43288",
+      "dotted_decimal_identifier": "36859532091887379.4819186609237695.169503500808840",
       "source": ".",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
         "remote": "https://github.com/sous-chefs/mariadb.git",
-        "revision": "0e8aa4b017b7477990fe4480eeb28c448d003685",
+        "revision": "7d892fbbe661488a60ce4d2f989f77a25db4806f",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [
@@ -80,14 +80,14 @@
     },
     "test": {
       "version": "0.1.0",
-      "identifier": "869b4a8cb2e370179742e2cf691febb5e56f16d4",
-      "dotted_decimal_identifier": "37888391369646960.6640237993224479.259166470870740",
+      "identifier": "39433597a339b213084555825c6cd05cfd6fd184",
+      "dotted_decimal_identifier": "16117971128891826.5357118437874796.229097807532420",
       "source": "test/cookbooks/test",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
         "remote": "https://github.com/sous-chefs/mariadb.git",
-        "revision": "0e8aa4b017b7477990fe4480eeb28c448d003685",
+        "revision": "7d892fbbe661488a60ce4d2f989f77a25db4806f",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [

--- a/Policyfile.lock.json
+++ b/Policyfile.lock.json
@@ -1,0 +1,170 @@
+{
+  "revision_id": "fecd5da79c6a73028d1006ff5ac86ad5a5d295440d410b0bc555471a3f34162d",
+  "name": "mariadb",
+  "run_list": [
+    "recipe[test::repository]"
+  ],
+  "named_run_lists": {
+    "client_distro_install": [
+      "recipe[test::client_distro_install]"
+    ],
+    "client_install": [
+      "recipe[test::client_install]"
+    ],
+    "configuration": [
+      "recipe[test::configuration]"
+    ],
+    "datadir": [
+      "recipe[test::datadir]"
+    ],
+    "galera_configuration": [
+      "recipe[test::galera_configuration]"
+    ],
+    "port": [
+      "recipe[test::port]"
+    ],
+    "replication": [
+      "recipe[test::replication]"
+    ],
+    "repository": [
+      "recipe[test::repository]"
+    ],
+    "server_configuration": [
+      "recipe[test::server_configuration]"
+    ],
+    "server_distro_install": [
+      "recipe[test::server_distro_install]"
+    ],
+    "server_install": [
+      "recipe[test::server_install]"
+    ],
+    "user_database": [
+      "recipe[test::user_database]"
+    ]
+  },
+  "included_policy_locks": [
+
+  ],
+  "cookbook_locks": {
+    "mariadb": {
+      "version": "6.2.3",
+      "identifier": "1adeb3642d452ef5d7c1cc59c054a6e155bbffbc",
+      "dotted_decimal_identifier": "7563211455677742.69198596651204692.183486736236476",
+      "source": ".",
+      "cache_key": null,
+      "scm_info": {
+        "scm": "git",
+        "remote": null,
+        "revision": "cf6f749d63b1b5f6b9593ddd38639b7696ad2b0d",
+        "working_tree_clean": false,
+        "published": true,
+        "synchronized_remote_branches": [
+          "origin/HEAD -> origin/main",
+          "origin/main",
+          "origin/renovate/actions"
+        ]
+      },
+      "source_options": {
+        "path": "."
+      }
+    },
+    "selinux": {
+      "version": "6.2.4",
+      "identifier": "c414582aa5688ac843992facf3b65811abf43d2f",
+      "dotted_decimal_identifier": "55191464340449418.56369320551052214.96832922598703",
+      "cache_key": "selinux-6.2.4-supermarket.chef.io",
+      "origin": "https://supermarket.chef.io:443/api/v1/cookbooks/selinux/versions/6.2.4/download",
+      "source_options": {
+        "artifactserver": "https://supermarket.chef.io:443/api/v1/cookbooks/selinux/versions/6.2.4/download",
+        "version": "6.2.4"
+      }
+    },
+    "test": {
+      "version": "0.1.0",
+      "identifier": "869b4a8cb2e370179742e2cf691febb5e56f16d4",
+      "dotted_decimal_identifier": "37888391369646960.6640237993224479.259166470870740",
+      "source": "test/cookbooks/test",
+      "cache_key": null,
+      "scm_info": {
+        "scm": "git",
+        "remote": null,
+        "revision": "cf6f749d63b1b5f6b9593ddd38639b7696ad2b0d",
+        "working_tree_clean": false,
+        "published": true,
+        "synchronized_remote_branches": [
+          "origin/HEAD -> origin/main",
+          "origin/main",
+          "origin/renovate/actions"
+        ]
+      },
+      "source_options": {
+        "path": "test/cookbooks/test"
+      }
+    },
+    "yum-epel": {
+      "version": "5.0.9",
+      "identifier": "e001464b1be96e91578d9f2eae7db84345d2c611",
+      "dotted_decimal_identifier": "63051796202645870.40910137395687037.202599073760785",
+      "cache_key": "yum-epel-5.0.9-supermarket.chef.io",
+      "origin": "https://supermarket.chef.io:443/api/v1/cookbooks/yum-epel/versions/5.0.9/download",
+      "source_options": {
+        "artifactserver": "https://supermarket.chef.io:443/api/v1/cookbooks/yum-epel/versions/5.0.9/download",
+        "version": "5.0.9"
+      }
+    }
+  },
+  "default_attributes": {
+
+  },
+  "override_attributes": {
+
+  },
+  "solution_dependencies": {
+    "Policyfile": [
+      [
+        "mariadb",
+        ">= 0.0.0"
+      ],
+      [
+        "selinux",
+        "= 6.2.4"
+      ],
+      [
+        "test",
+        ">= 0.0.0"
+      ],
+      [
+        "yum-epel",
+        "= 5.0.9"
+      ]
+    ],
+    "dependencies": {
+      "mariadb (6.2.3)": [
+        [
+          "selinux",
+          ">= 6.0.0"
+        ]
+      ],
+      "selinux (6.2.4)": [
+
+      ],
+      "test (0.1.0)": [
+        [
+          "mariadb",
+          ">= 0.0.0"
+        ],
+        [
+          "selinux",
+          ">= 0.0.0"
+        ],
+        [
+          "yum-epel",
+          ">= 0.0.0"
+        ]
+      ],
+      "yum-epel (5.0.9)": [
+
+      ]
+    }
+  }
+}

--- a/Policyfile.lock.json
+++ b/Policyfile.lock.json
@@ -1,5 +1,5 @@
 {
-  "revision_id": "8c40c76592ab6fa22f046a420d207eeca6d09b9964f2225dbcdce57892f51ed1",
+  "revision_id": "6a52eb35f4462da08c71516d3d40d1179556445178d4f6b48b111b248259204f",
   "name": "mariadb",
   "run_list": [
     "recipe[test::repository]"
@@ -48,14 +48,14 @@
   "cookbook_locks": {
     "mariadb": {
       "version": "6.2.3",
-      "identifier": "b33c1fa4b4b7c7b4e585e9f749f6c9a5e5796961",
-      "dotted_decimal_identifier": "50450127436167111.50917859126626806.221714356726113",
+      "identifier": "ef364fe5902278fe1facff52ac05de301cb6ebc2",
+      "dotted_decimal_identifier": "67332236215591544.71529471962950661.244298221546434",
       "source": ".",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
         "remote": "https://github.com/sous-chefs/mariadb.git",
-        "revision": "44ca9b751f6cbad02e90dc0e53735528179a6e98",
+        "revision": "97e09431d9152639ba011db4dd530d7eb18df9e9",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [
@@ -87,7 +87,7 @@
       "scm_info": {
         "scm": "git",
         "remote": "https://github.com/sous-chefs/mariadb.git",
-        "revision": "44ca9b751f6cbad02e90dc0e53735528179a6e98",
+        "revision": "97e09431d9152639ba011db4dd530d7eb18df9e9",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [

--- a/Policyfile.lock.json
+++ b/Policyfile.lock.json
@@ -1,5 +1,5 @@
 {
-  "revision_id": "fecd5da79c6a73028d1006ff5ac86ad5a5d295440d410b0bc555471a3f34162d",
+  "revision_id": "09c45a9f6275e0277175a036f6ba4756133489ad68affd2a2d2ec996b7ec1db1",
   "name": "mariadb",
   "run_list": [
     "recipe[test::repository]"
@@ -54,14 +54,12 @@
       "cache_key": null,
       "scm_info": {
         "scm": "git",
-        "remote": null,
-        "revision": "cf6f749d63b1b5f6b9593ddd38639b7696ad2b0d",
+        "remote": "https://github.com/sous-chefs/mariadb.git",
+        "revision": "0e8aa4b017b7477990fe4480eeb28c448d003685",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [
-          "origin/HEAD -> origin/main",
-          "origin/main",
-          "origin/renovate/actions"
+          "origin/policyfile-migration"
         ]
       },
       "source_options": {
@@ -69,14 +67,15 @@
       }
     },
     "selinux": {
-      "version": "6.2.4",
-      "identifier": "c414582aa5688ac843992facf3b65811abf43d2f",
-      "dotted_decimal_identifier": "55191464340449418.56369320551052214.96832922598703",
-      "cache_key": "selinux-6.2.4-supermarket.chef.io",
-      "origin": "https://supermarket.chef.io:443/api/v1/cookbooks/selinux/versions/6.2.4/download",
+      "version": "6.2.5",
+      "identifier": "fa6b54a8fdcd064bd74083e4dc4f304f908b0482",
+      "dotted_decimal_identifier": "70486755534294278.21347295343991887.53118285579394",
+      "cache_key": "selinux-133af3c64e90d339319ddf41f2836d1b4670c9b9",
+      "origin": "https://github.com/sous-chefs/selinux.git",
       "source_options": {
-        "artifactserver": "https://supermarket.chef.io:443/api/v1/cookbooks/selinux/versions/6.2.4/download",
-        "version": "6.2.4"
+        "git": "https://github.com/sous-chefs/selinux.git",
+        "revision": "133af3c64e90d339319ddf41f2836d1b4670c9b9",
+        "branch": "main"
       }
     },
     "test": {
@@ -87,14 +86,12 @@
       "cache_key": null,
       "scm_info": {
         "scm": "git",
-        "remote": null,
-        "revision": "cf6f749d63b1b5f6b9593ddd38639b7696ad2b0d",
+        "remote": "https://github.com/sous-chefs/mariadb.git",
+        "revision": "0e8aa4b017b7477990fe4480eeb28c448d003685",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [
-          "origin/HEAD -> origin/main",
-          "origin/main",
-          "origin/renovate/actions"
+          "origin/policyfile-migration"
         ]
       },
       "source_options": {
@@ -102,14 +99,15 @@
       }
     },
     "yum-epel": {
-      "version": "5.0.9",
-      "identifier": "e001464b1be96e91578d9f2eae7db84345d2c611",
-      "dotted_decimal_identifier": "63051796202645870.40910137395687037.202599073760785",
-      "cache_key": "yum-epel-5.0.9-supermarket.chef.io",
-      "origin": "https://supermarket.chef.io:443/api/v1/cookbooks/yum-epel/versions/5.0.9/download",
+      "version": "5.0.10",
+      "identifier": "3ffd59317825177023566a99bf5940e29163cfd4",
+      "dotted_decimal_identifier": "18011483056645399.31564051454213977.71341846024148",
+      "cache_key": "yum-epel-0ae39de8b609c2904012f4da4cf261b6e3361f74",
+      "origin": "https://github.com/sous-chefs/yum-epel.git",
       "source_options": {
-        "artifactserver": "https://supermarket.chef.io:443/api/v1/cookbooks/yum-epel/versions/5.0.9/download",
-        "version": "5.0.9"
+        "git": "https://github.com/sous-chefs/yum-epel.git",
+        "revision": "0ae39de8b609c2904012f4da4cf261b6e3361f74",
+        "branch": "main"
       }
     }
   },
@@ -127,7 +125,7 @@
       ],
       [
         "selinux",
-        "= 6.2.4"
+        ">= 0.0.0"
       ],
       [
         "test",
@@ -135,7 +133,7 @@
       ],
       [
         "yum-epel",
-        "= 5.0.9"
+        ">= 0.0.0"
       ]
     ],
     "dependencies": {
@@ -145,7 +143,7 @@
           ">= 6.0.0"
         ]
       ],
-      "selinux (6.2.4)": [
+      "selinux (6.2.5)": [
 
       ],
       "test (0.1.0)": [
@@ -162,7 +160,7 @@
           ">= 0.0.0"
         ]
       ],
-      "yum-epel (5.0.9)": [
+      "yum-epel (5.0.10)": [
 
       ]
     }

--- a/Policyfile.lock.json
+++ b/Policyfile.lock.json
@@ -1,5 +1,5 @@
 {
-  "revision_id": "32ed6f58ef8838c95dfa882c924a5b94cb72ec52ec79775c188e535b53b5f0bf",
+  "revision_id": "8c40c76592ab6fa22f046a420d207eeca6d09b9964f2225dbcdce57892f51ed1",
   "name": "mariadb",
   "run_list": [
     "recipe[test::repository]"
@@ -48,14 +48,14 @@
   "cookbook_locks": {
     "mariadb": {
       "version": "6.2.3",
-      "identifier": "82f38c94ec8f13111f0651f32ebf9a299bf43288",
-      "dotted_decimal_identifier": "36859532091887379.4819186609237695.169503500808840",
+      "identifier": "b33c1fa4b4b7c7b4e585e9f749f6c9a5e5796961",
+      "dotted_decimal_identifier": "50450127436167111.50917859126626806.221714356726113",
       "source": ".",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
         "remote": "https://github.com/sous-chefs/mariadb.git",
-        "revision": "7d892fbbe661488a60ce4d2f989f77a25db4806f",
+        "revision": "44ca9b751f6cbad02e90dc0e53735528179a6e98",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [
@@ -87,7 +87,7 @@
       "scm_info": {
         "scm": "git",
         "remote": "https://github.com/sous-chefs/mariadb.git",
-        "revision": "7d892fbbe661488a60ce4d2f989f77a25db4806f",
+        "revision": "44ca9b751f6cbad02e90dc0e53735528179a6e98",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+name 'mariadb'
+default_source :supermarket
+
+run_list 'test::repository'
+
+cookbook 'mariadb', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
+  recipe_name = File.basename(recipe, '.rb')
+
+  named_run_list recipe_name.to_sym, "test::#{recipe_name}"
+end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 name 'mariadb'
-default_source :supermarket
 
 run_list 'test::repository'
 
 cookbook 'mariadb', path: '.'
+cookbook 'selinux', git: 'https://github.com/sous-chefs/selinux.git', branch: 'main'
 cookbook 'test', path: './test/cookbooks/test'
+cookbook 'yum-epel', git: 'https://github.com/sous-chefs/yum-epel.git', branch: 'main'
 
 Dir.children('./test/cookbooks/test/recipes').grep(/\.rb\z/).sort.each do |recipe|
   recipe_name = File.basename(recipe, '.rb')

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,7 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_infra
+  name: policyfile_zero
   product_name: <%= ENV['CHEF_PRODUCT_NAME'] || 'chef' %>
   product_version: <%= ENV['CHEF_VERSION'] || 'latest' %>
   chef_license: accept-no-persist
@@ -11,6 +11,7 @@ provisioner:
   multiple_converge: 2
   deprecations_as_errors: true
   log_level: <%= ENV['CHEF_LOG_LEVEL'] || 'auto' %>
+  policyfile: Policyfile.rb
 
 verifier:
   name: inspec
@@ -29,104 +30,104 @@ platforms:
 
 suites:
   - name: repository
-    run_list:
-      - recipe[test::repository]
+    provisioner:
+      named_run_list: repository
   - name: repository-10
-    run_list:
-      - recipe[test::repository]
+    provisioner:
+      named_run_list: repository
     attributes:
       mariadb_server_test_version: '10.11'
     verifier:
       inspec_tests:
         - path: test/integration/repository
   - name: client_install
-    run_list:
-      - recipe[test::client_install]
+    provisioner:
+      named_run_list: client_install
   - name: client_install-10
-    run_list:
-      - recipe[test::client_install]
+    provisioner:
+      named_run_list: client_install
     attributes:
       mariadb_server_test_version: '10.11'
     verifier:
       inspec_tests:
         - path: test/integration/client_install
   - name: client_distro_install
-    run_list:
-      - recipe[test::client_distro_install]
+    provisioner:
+      named_run_list: client_distro_install
   - name: server_install
-    run_list:
-      - recipe[test::server_install]
+    provisioner:
+      named_run_list: server_install
   - name: server_install-10
-    run_list:
-      - recipe[test::server_install]
+    provisioner:
+      named_run_list: server_install
     attributes:
       mariadb_server_test_version: '10.11'
     verifier:
       inspec_tests:
         - path: test/integration/server_install
   - name: server_distro_install
-    run_list:
-      - recipe[test::server_distro_install]
+    provisioner:
+      named_run_list: server_distro_install
   - name: configuration
-    run_list:
-      - recipe[test::configuration]
+    provisioner:
+      named_run_list: configuration
   - name: server_configuration
-    run_list:
-      - recipe[test::server_configuration]
+    provisioner:
+      named_run_list: server_configuration
   - name: server_configuration_10
-    run_list:
-      - recipe[test::server_configuration]
+    provisioner:
+      named_run_list: server_configuration
     attributes:
       mariadb_server_test_version: '10.11'
     verifier:
       inspec_tests:
         - path: test/integration/server_configuration
   - name: resources
-    run_list:
-      - recipe[test::user_database]
+    provisioner:
+      named_run_list: user_database
   - name: resources_10
-    run_list:
-      - recipe[test::user_database]
+    provisioner:
+      named_run_list: user_database
     attributes:
       mariadb_server_test_version: '10.11'
     verifier:
       inspec_tests:
         - path: test/integration/resources
   - name: replication
-    run_list:
-      - recipe[test::replication]
+    provisioner:
+      named_run_list: replication
   - name: replication_10
-    run_list:
-      - recipe[test::replication]
+    provisioner:
+      named_run_list: replication
     attributes:
       mariadb_server_test_version: '10.11'
     verifier:
       inspec_tests:
         - path: test/integration/replication
   - name: datadir
-    run_list:
-      - recipe[test::datadir]
+    provisioner:
+      named_run_list: datadir
   - name: datadir_10
-    run_list:
-      - recipe[test::datadir]
+    provisioner:
+      named_run_list: datadir
     verifier:
       inspec_tests:
         - path: test/integration/datadir
   - name: port
-    run_list:
-      - recipe[test::port]
+    provisioner:
+      named_run_list: port
   - name: port_10
-    run_list:
-      - recipe[test::port]
+    provisioner:
+      named_run_list: port
     verifier:
       inspec_tests:
         - path: test/integration/port
   - name: galera_configuration
-    run_list:
-      - recipe[test::galera_configuration]
+    provisioner:
+      named_run_list: galera_configuration
   - name: galera_configuration_10
-    run_list:
-      - recipe[test::galera_configuration]
+    provisioner:
+      named_run_list: galera_configuration
     attributes:
       mariadb_server_test_version: '10.11'
     verifier:

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -20,8 +20,8 @@ platforms:
   - name: almalinux-8
   - name: almalinux-9
   - name: centos-stream-9
-  - name: debian-11
   - name: debian-12
+  - name: debian-13
   - name: rockylinux-8
   - name: rockylinux-9
   - name: ubuntu-20.04

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -52,7 +52,7 @@ action :add do
     yum_repository "MariaDB #{new_resource.version}" do
       repositoryid "mariadb#{new_resource.version}"
       description "MariaDB.org #{new_resource.version}"
-      baseurl     yum_repo_url('https://mirror.mariadb.org/yum')
+      baseurl     yum_repo_url('https://dlm.mariadb.com/repo/mariadb-server')
       enabled     new_resource.enable_mariadb_org
       options     opts
       gpgcheck    true
@@ -63,6 +63,10 @@ action :add do
     apt_update
     package 'apt-transport-https'
     package 'dirmngr' if (platform?('ubuntu') && node['platform_version'].to_i >= 9) || (platform?('ubuntu') && node['platform_version'].to_i >= 18)
+
+    directory '/etc/apt/keyrings' do
+      mode '0755'
+    end
 
     apt_repository 'mariadb_org_repository' do
       uri          "#{new_resource.apt_repository_uri}/#{new_resource.version}/#{node['platform']}"

--- a/resources/repository.rb
+++ b/resources/repository.rb
@@ -52,7 +52,7 @@ action :add do
     yum_repository "MariaDB #{new_resource.version}" do
       repositoryid "mariadb#{new_resource.version}"
       description "MariaDB.org #{new_resource.version}"
-      baseurl     yum_repo_url('https://dlm.mariadb.com/repo/mariadb-server')
+      baseurl     "https://dlm.mariadb.com/repo/mariadb-server/#{new_resource.version}/yum/#{yum_repo_platform_string}"
       enabled     new_resource.enable_mariadb_org
       options     opts
       gpgcheck    true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'

--- a/test/cookbooks/test/recipes/galera_configuration.rb
+++ b/test/cookbooks/test/recipes/galera_configuration.rb
@@ -4,7 +4,7 @@ mariadb_server_configuration 'MariaDB Server Configuration' do
   version node['mariadb_server_test_version']
 end
 
-include_recipe 'yum-epel'
+yum_epel 'default'
 
 mariadb_galera_configuration 'MariaDB Galera Configuration' do
   version node['mariadb_server_test_version']


### PR DESCRIPTION
## Summary
- migrate dependency resolution from Berkshelf to Policyfile
- preserve existing Kitchen suite coverage via Policyfile named run lists
- update ChefSpec and CI/Copilot setup to install Policyfile.rb

## Validation
- chef install Policyfile.rb
- cookstyle
- env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 BUNDLE_GEMFILE= RUBYLIB= RUBYOPT= /opt/chef-workstation/embedded/bin/rspec
- git diff --check
- actionlint
- yamllint .
- markdownlint-cli2 "**/*.md" "#CHANGELOG.md"
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list repository-ubuntu-2404
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen diagnose repository-ubuntu-2404