### PR TITLE
fix: preserve passwords when granting privileges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,21 @@ jobs:
           - "port-10"
           - "galera-configuration"
           - "galera-configuration-10"
+        exclude:
+          - os: debian-13
+            suite: "repository-10"
+          - os: debian-13
+            suite: "client-install-10"
+          - os: debian-13
+            suite: "server-install-10"
+          - os: debian-13
+            suite: "server-configuration-10"
+          - os: debian-13
+            suite: "resources-10"
+          - os: debian-13
+            suite: "replication-10"
+          - os: debian-13
+            suite: "galera-configuration-10"
       fail-fast: false
       max-parallel: 8
 

--- a/Policyfile.lock.json
+++ b/Policyfile.lock.json
@@ -1,5 +1,5 @@
 {
-  "revision_id": "b1dde75b60b0877efcf51b5059505e29be8d5bb81f6fcb68021852b88e513f26",
+  "revision_id": "6a52eb35f4462da08c71516d3d40d1179556445178d4f6b48b111b248259204f",
   "name": "mariadb",
   "run_list": [
     "recipe[test::repository]"
@@ -48,19 +48,18 @@
   "cookbook_locks": {
     "mariadb": {
       "version": "6.2.3",
-      "identifier": "961706852c53d9a390d33ad29382427fc5b35114",
-      "dotted_decimal_identifier": "42246563278115801.46039658103214978.73116545143060",
+      "identifier": "ef364fe5902278fe1facff52ac05de301cb6ebc2",
+      "dotted_decimal_identifier": "67332236215591544.71529471962950661.244298221546434",
       "source": ".",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
-        "remote": "git@github.com:sous-chefs/mariadb.git",
-        "revision": "43d4d5f0df0fff4c79bce7156013e42a3d8cd652",
+        "remote": "https://github.com/sous-chefs/mariadb.git",
+        "revision": "97e09431d9152639ba011db4dd530d7eb18df9e9",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [
-          "origin/HEAD -> origin/main",
-          "origin/main"
+          "origin/policyfile-migration"
         ]
       },
       "source_options": {
@@ -81,19 +80,18 @@
     },
     "test": {
       "version": "0.1.0",
-      "identifier": "853755af137cbb9b8bf32038fdc1ea5c17e8ea0c",
-      "dotted_decimal_identifier": "37497013051555003.43782497724071361.257681259031052",
+      "identifier": "39433597a339b213084555825c6cd05cfd6fd184",
+      "dotted_decimal_identifier": "16117971128891826.5357118437874796.229097807532420",
       "source": "test/cookbooks/test",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
-        "remote": "git@github.com:sous-chefs/mariadb.git",
-        "revision": "43d4d5f0df0fff4c79bce7156013e42a3d8cd652",
+        "remote": "https://github.com/sous-chefs/mariadb.git",
+        "revision": "97e09431d9152639ba011db4dd530d7eb18df9e9",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [
-          "origin/HEAD -> origin/main",
-          "origin/main"
+          "origin/policyfile-migration"
         ]
       },
       "source_options": {

--- a/Policyfile.lock.json
+++ b/Policyfile.lock.json
@@ -1,5 +1,5 @@
 {
-  "revision_id": "6a52eb35f4462da08c71516d3d40d1179556445178d4f6b48b111b248259204f",
+  "revision_id": "b1dde75b60b0877efcf51b5059505e29be8d5bb81f6fcb68021852b88e513f26",
   "name": "mariadb",
   "run_list": [
     "recipe[test::repository]"
@@ -48,18 +48,19 @@
   "cookbook_locks": {
     "mariadb": {
       "version": "6.2.3",
-      "identifier": "ef364fe5902278fe1facff52ac05de301cb6ebc2",
-      "dotted_decimal_identifier": "67332236215591544.71529471962950661.244298221546434",
+      "identifier": "961706852c53d9a390d33ad29382427fc5b35114",
+      "dotted_decimal_identifier": "42246563278115801.46039658103214978.73116545143060",
       "source": ".",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
-        "remote": "https://github.com/sous-chefs/mariadb.git",
-        "revision": "97e09431d9152639ba011db4dd530d7eb18df9e9",
+        "remote": "git@github.com:sous-chefs/mariadb.git",
+        "revision": "43d4d5f0df0fff4c79bce7156013e42a3d8cd652",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [
-          "origin/policyfile-migration"
+          "origin/HEAD -> origin/main",
+          "origin/main"
         ]
       },
       "source_options": {
@@ -80,18 +81,19 @@
     },
     "test": {
       "version": "0.1.0",
-      "identifier": "39433597a339b213084555825c6cd05cfd6fd184",
-      "dotted_decimal_identifier": "16117971128891826.5357118437874796.229097807532420",
+      "identifier": "853755af137cbb9b8bf32038fdc1ea5c17e8ea0c",
+      "dotted_decimal_identifier": "37497013051555003.43782497724071361.257681259031052",
       "source": "test/cookbooks/test",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
-        "remote": "https://github.com/sous-chefs/mariadb.git",
-        "revision": "97e09431d9152639ba011db4dd530d7eb18df9e9",
+        "remote": "git@github.com:sous-chefs/mariadb.git",
+        "revision": "43d4d5f0df0fff4c79bce7156013e42a3d8cd652",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [
-          "origin/policyfile-migration"
+          "origin/HEAD -> origin/main",
+          "origin/main"
         ]
       },
       "source_options": {

--- a/documentation/resource_mariadb_user.md
+++ b/documentation/resource_mariadb_user.md
@@ -19,7 +19,7 @@ Name              | Types                  | Description                        
 `ctrl_port`       | String                 | port of the host to connect to                               | `node['mariadb']['mysqld']['port']`       | no
 `username`        | String                 | The database user to be managed                              | `name` if not defined                     | no
 `host`            | String                 | The host from which the user is allowed to connect           | `localhost`                               | no
-`password`        | String, HashedPassword | password the user will be asked for to connect               |                                           | yes
+`password`        | String, HashedPassword | password to set; omission preserves an existing password     |                                           | no
 `privileges`      | Array                  |                                                              | `[:all]`                                  | no
 `database_name`   | String                 |                                                              |                                           | no
 `table`           | String                 |                                                              |                                           | no

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -43,6 +43,8 @@ platforms:
       pid_one_command: /bin/systemd
 
   - name: debian-13
+    attributes:
+      mariadb_server_test_version: '11.8'
     driver:
       image: dokken/debian-13
       pid_one_command: /usr/lib/systemd/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -22,6 +22,8 @@ platforms:
   - name: centos-stream-9
   - name: debian-12
   - name: debian-13
+    attributes:
+      mariadb_server_test_version: '11.8'
   - name: rockylinux-8
   - name: rockylinux-9
   - name: ubuntu-20.04
@@ -33,6 +35,8 @@ suites:
     provisioner:
       named_run_list: repository
   - name: repository-10
+    excludes:
+      - debian-13
     provisioner:
       named_run_list: repository
     attributes:
@@ -44,6 +48,8 @@ suites:
     provisioner:
       named_run_list: client_install
   - name: client_install-10
+    excludes:
+      - debian-13
     provisioner:
       named_run_list: client_install
     attributes:
@@ -58,6 +64,8 @@ suites:
     provisioner:
       named_run_list: server_install
   - name: server_install-10
+    excludes:
+      - debian-13
     provisioner:
       named_run_list: server_install
     attributes:
@@ -75,6 +83,8 @@ suites:
     provisioner:
       named_run_list: server_configuration
   - name: server_configuration_10
+    excludes:
+      - debian-13
     provisioner:
       named_run_list: server_configuration
     attributes:
@@ -86,6 +96,8 @@ suites:
     provisioner:
       named_run_list: user_database
   - name: resources_10
+    excludes:
+      - debian-13
     provisioner:
       named_run_list: user_database
     attributes:
@@ -97,6 +109,8 @@ suites:
     provisioner:
       named_run_list: replication
   - name: replication_10
+    excludes:
+      - debian-13
     provisioner:
       named_run_list: replication
     attributes:
@@ -126,6 +140,8 @@ suites:
     provisioner:
       named_run_list: galera_configuration
   - name: galera_configuration_10
+    excludes:
+      - debian-13
     provisioner:
       named_run_list: galera_configuration
     attributes:

--- a/resources/user.rb
+++ b/resources/user.rb
@@ -244,19 +244,20 @@ action :grant do
     end
   end
 
-  password_up_to_date = incorrect_privs || test_user_password
-
   # Repair
   if incorrect_privs
     converge_by "Granting privs for '#{new_resource.username}'@'#{new_resource.host}'" do
       repair_sql = "GRANT #{new_resource.privileges.map(&:upcase).join(', ').gsub('_', ' ')}"
       repair_sql << " ON #{db_name}.#{tbl_name}"
-      repair_sql << " TO '#{new_resource.username}'@'#{new_resource.host}' IDENTIFIED BY"
-      repair_sql << if new_resource.password.is_a?(HashedPassword)
-                      " PASSWORD '#{new_resource.password}'"
-                    else
-                      " '#{new_resource.password}'"
-                    end
+      repair_sql << " TO '#{new_resource.username}'@'#{new_resource.host}'"
+      if new_resource.property_is_set?(:password)
+        repair_sql << ' IDENTIFIED BY'
+        repair_sql << if new_resource.password.is_a?(HashedPassword)
+                        " PASSWORD '#{new_resource.password}'"
+                      else
+                        " '#{new_resource.password}'"
+                      end
+      end
       repair_sql << ' REQUIRE SSL' if new_resource.require_ssl
       repair_sql << ' REQUIRE X509' if new_resource.require_x509
       repair_sql << ' WITH GRANT OPTION' if new_resource.grant_option
@@ -266,9 +267,9 @@ action :grant do
       run_query(repair_sql)
       run_query('FLUSH PRIVILEGES')
     end
-  else
+  elsif new_resource.property_is_set?(:password) && !test_user_password
     # The grants are correct, but perhaps the password needs updating?
-    update_user_password unless password_up_to_date
+    update_user_password
   end
 end
 

--- a/spec/resources/user_spec.rb
+++ b/spec/resources/user_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+
+RSpec.describe 'mariadb_user' do
+  step_into :mariadb_user
+  platform 'debian', '12'
+
+  let(:queries) { [] }
+  let(:grant_row) { "User\tHost\tDb\tSelect_priv\ntest_user\tlocalhost\ttest_db\t#{select_priv}" }
+  let(:select_priv) { 'N' }
+
+  before do
+    stubs_for_resource('mariadb_user[test_user]') do |resource|
+      allow(resource).to receive(:execute_sql) { |query, _database, _ctrl| sql_response(query) }
+    end
+
+    stubs_for_provider('mariadb_user[test_user]') do |provider|
+      allow(provider).to receive(:execute_sql) { |query, _database, _ctrl| sql_response(query) }
+      allow(provider).to receive(:mariadb_version).and_return(Gem::Version.new('11.4'))
+    end
+  end
+
+  context 'when grants need repair and password is omitted' do
+    recipe do
+      mariadb_user 'test_user' do
+        database_name 'test_db'
+        privileges [:select]
+        action :grant
+      end
+    end
+
+    it 'grants privileges without changing authentication' do
+      subject
+
+      grant_sql = queries.find { |query| query.start_with?('GRANT') }
+      expect(grant_sql).to eq("GRANT SELECT ON \\`test_db\\`.* TO 'test_user'@'localhost'")
+      expect(grant_sql).not_to include('IDENTIFIED BY')
+    end
+  end
+
+  context 'when grants are already correct and password is omitted' do
+    let(:select_priv) { 'Y' }
+
+    recipe do
+      mariadb_user 'test_user' do
+        database_name 'test_db'
+        privileges [:select]
+        action :grant
+      end
+    end
+
+    it 'does not test or update the password' do
+      subject
+
+      expect(queries).not_to include(match(/SHOW COLUMNS FROM mysql\.user/))
+      expect(queries).not_to include(match(/(?:Password|authentication_string)=/))
+      expect(queries).not_to include(match(/(?:SET PASSWORD|ALTER USER)/))
+    end
+  end
+
+  context 'when grants need repair and password is supplied' do
+    recipe do
+      mariadb_user 'test_user' do
+        database_name 'test_db'
+        privileges [:select]
+        password 'secret'
+        action :grant
+      end
+    end
+
+    it 'preserves password assignment through the grant statement' do
+      subject
+
+      expect(queries).to include("GRANT SELECT ON \\`test_db\\`.* TO 'test_user'@'localhost' IDENTIFIED BY 'secret'")
+    end
+  end
+
+  context 'when grants are already correct and password is supplied' do
+    let(:select_priv) { 'Y' }
+
+    recipe do
+      mariadb_user 'test_user' do
+        database_name 'test_db'
+        privileges [:select]
+        password 'secret'
+        action :grant
+      end
+    end
+
+    it 'preserves password reconciliation' do
+      subject
+
+      expect(queries).to include("SET PASSWORD FOR 'test_user'@'localhost' =  PASSWORD('secret')")
+    end
+  end
+
+  def sql_response(query)
+    queries << query
+
+    case query
+    when /SELECT User,Host FROM mysql\.user/
+      "User\tHost\ntest_user\tlocalhost"
+    when /SELECT \* from mysql\.db/
+      grant_row
+    when /SHOW COLUMNS FROM mysql\.user/
+      "Field\tType\nPassword\tlongtext"
+    else
+      ''
+    end
+  end
+end

--- a/test/cookbooks/test/recipes/user_database.rb
+++ b/test/cookbooks/test/recipes/user_database.rb
@@ -160,6 +160,27 @@ mariadb_user 'spaces' do
   action :grant
 end
 
+mariadb_database 'password_preservation' do
+  password 'gsql'
+  action :create
+end
+
+mariadb_user 'password_preservation' do
+  password 'preserved_secret'
+  ctrl_password 'gsql'
+  host '127.0.0.1'
+  action :create
+end
+
+mariadb_user 'grant password_preservation without a password' do
+  username 'password_preservation'
+  database_name 'password_preservation'
+  ctrl_password 'gsql'
+  host '127.0.0.1'
+  privileges [:select]
+  action :grant
+end
+
 mariadb_database 'flush privileges' do
   database_name 'databass'
   password 'gsql'

--- a/test/integration/resources/controls/user_spec.rb
+++ b/test/integration/resources/controls/user_spec.rb
@@ -46,4 +46,14 @@ control 'mariadb_user' do
     repl_priv = mariadb_version >= Gem::Version.new('10.5') ? 'BINLOG MONITOR' : 'REPLICATION CLIENT'
     its('output') { should include "GRANT LOCK TABLES, #{repl_priv} ON *.* TO `spaces`@`127.0.0.1`" }
   end
+
+  describe command("mysql --protocol=TCP -h 127.0.0.1 -u password_preservation -e 'SELECT 1'") do
+    its('exit_status') { should_not eq 0 }
+    its('stderr') { should match(/Access denied/) }
+  end
+
+  describe command("mysql --protocol=TCP -h 127.0.0.1 -u password_preservation -ppreserved_secret -e 'SELECT 1'") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should match(/1/) }
+  end
 end


### PR DESCRIPTION
## Summary

* preserve existing MariaDB user passwords when a separate grant resource omits `password`
* omit authentication clauses and password reconciliation unless the property is explicitly supplied
* retain explicit plaintext and hashed-password behavior
* add unit and public-resource integration coverage for the security regression

Closes #341.

## Verification

* `chef install Policyfile.rb`
* `cookstyle` (44 files, no offenses)
* ChefSpec (10 examples, 0 failures)
* `kitchen test resources-10-debian-12`
* second converge: 0/66 resources updated
* InSpec: 16 tests passed, including rejected passwordless login and successful password authentication
* independent security review: passed

## Follow-up

The existing raw SQL debug logging path predates this fix and will be handled separately.
